### PR TITLE
Expose LineSearch attribute

### DIFF
--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -135,7 +135,7 @@ class ConjugateGradient(Solver):
 
             # Execute line search
             stepsize, newx = linesearch.search(objective, man, x, desc_dir,
-                                                   cost, df0)
+                                               cost, df0)
 
             # Compute the new cost-related quantities for newx
             newcost = objective(newx)

--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -4,7 +4,7 @@ import time
 
 import numpy as np
 
-from pymanopt.solvers import linesearch as default_linesearchers
+from pymanopt.solvers.linesearch import LineSearchAdaptive
 from pymanopt.solvers.solver import Solver
 from pymanopt import tools
 
@@ -21,7 +21,8 @@ class ConjugateGradient(Solver):
     """
 
     def __init__(self, beta_type=BetaTypes.HestenesStiefel, orth_value=np.inf,
-                 linesearch=None, *args, **kwargs):
+                 LineSearch=LineSearchAdaptive, *args,
+                 **kwargs):
         """
         Instantiate gradient solver class.
         Variable attributes (defaults in brackets):
@@ -32,18 +33,15 @@ class ConjugateGradient(Solver):
                 Parameter for Powell's restart strategy. An infinite
                 value disables this strategy. See in code formula for
                 the specific criterion used.
-            - linesearch (None)
-                If None LineSearchAdaptive will be used.
+            - linesearch (LineSearchAdaptive)
+                The linesearch method to use.
         """
         super(ConjugateGradient, self).__init__(*args, **kwargs)
 
         self._beta_type = beta_type
         self._orth_value = orth_value
 
-        if linesearch is None:
-            self._searcher = default_linesearchers.LineSearchAdaptive()
-        else:
-            self._searcher = linesearch
+        self.LineSearch = LineSearch
 
     def solve(self, problem, x=None):
         """
@@ -70,6 +68,8 @@ class ConjugateGradient(Solver):
         verbosity = problem.verbosity
         objective = problem.cost
         gradient = problem.grad
+
+        linesearch = self.LineSearch()
 
         # If no starting point is specified, generate one at random.
         if x is None:
@@ -98,7 +98,7 @@ class ConjugateGradient(Solver):
         self._start_optlog(extraiterfields=['gradnorm'],
                            solverparams={'beta_type': self._beta_type,
                                          'orth_value': self._orth_value,
-                                         'linesearcher': self._searcher})
+                                         'linesearcher': linesearch})
 
         while True:
             if verbosity >= 2:
@@ -134,7 +134,7 @@ class ConjugateGradient(Solver):
                 df0 = -gradPgrad
 
             # Execute line search
-            stepsize, newx = self._searcher.search(objective, man, x, desc_dir,
+            stepsize, newx = linesearch.search(objective, man, x, desc_dir,
                                                    cost, df0)
 
             # Compute the new cost-related quantities for newx

--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -21,7 +21,7 @@ class ConjugateGradient(Solver):
     """
 
     def __init__(self, beta_type=BetaTypes.HestenesStiefel, orth_value=np.inf,
-                 LineSearch=LineSearchAdaptive, *args,
+                 linesearch=LineSearchAdaptive(), *args,
                  **kwargs):
         """
         Instantiate gradient solver class.
@@ -41,7 +41,7 @@ class ConjugateGradient(Solver):
         self._beta_type = beta_type
         self._orth_value = orth_value
 
-        self.LineSearch = LineSearch
+        self.linesearch = linesearch
 
     def solve(self, problem, x=None):
         """
@@ -69,7 +69,7 @@ class ConjugateGradient(Solver):
         objective = problem.cost
         gradient = problem.grad
 
-        linesearch = self.LineSearch()
+        linesearch = self.linesearch
 
         # If no starting point is specified, generate one at random.
         if x is None:

--- a/pymanopt/solvers/linesearch.py
+++ b/pymanopt/solvers/linesearch.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 
-class LineSearch(object):
+class LineSearchBackTracking(object):
     """
-    Line-search based on linesearch.m and linesearch_adaptive.m in the manopt
-    MATLAB package.
+    Back-tracking line-search based on linesearch.m in the manopt MATLAB
+    package.
     """
 
     def __init__(self, contraction_factor=.5, optimism=2,

--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import time
 
-from pymanopt.solvers import linesearch as default_linesearchers
+from pymanopt.solvers.linesearch import *
 from pymanopt.solvers.solver import Solver
 
 
@@ -12,13 +12,10 @@ class SteepestDescent(Solver):
     steepestdescent.m from the manopt MATLAB package.
     """
 
-    def __init__(self, linesearch=None, *args, **kwargs):
+    def __init__(self, LineSearch=LineSearchBackTracking, *args, **kwargs):
         super(SteepestDescent, self).__init__(*args, **kwargs)
 
-        if linesearch is None:
-            self._searcher = default_linesearchers.LineSearch()
-        else:
-            self._searcher = linesearch
+        self.LineSearch = LineSearch
 
     # Function to solve optimisation problem using steepest descent.
     def solve(self, problem, x=None):
@@ -46,6 +43,8 @@ class SteepestDescent(Solver):
         objective = problem.cost
         gradient = problem.grad
 
+        linesearch = self.LineSearch()
+
         # If no starting point is specified, generate one at random.
         if x is None:
             x = man.rand()
@@ -58,7 +57,7 @@ class SteepestDescent(Solver):
             print(" iter\t\t   cost val\t    grad. norm")
 
         self._start_optlog(extraiterfields=['gradnorm'],
-                           solverparams={'linesearcher': self._searcher})
+                           solverparams={'linesearcher': linesearch})
 
         while True:
             # Calculate new cost, grad and gradnorm
@@ -77,7 +76,7 @@ class SteepestDescent(Solver):
             desc_dir = -grad
 
             # Perform line-search
-            stepsize, x = self._searcher.search(objective, man, x, desc_dir,
+            stepsize, x = linesearch.search(objective, man, x, desc_dir,
                                                 cost, -gradnorm**2)
 
             stop_reason = self._check_stopping_criterion(

--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import time
 
-from pymanopt.solvers.linesearch import *
+from pymanopt.solvers.linesearch import LineSearchBackTracking
 from pymanopt.solvers.solver import Solver
 
 
@@ -76,8 +76,8 @@ class SteepestDescent(Solver):
             desc_dir = -grad
 
             # Perform line-search
-            stepsize, x = linesearch.search(objective, man, x, desc_dir,
-                                                cost, -gradnorm**2)
+            stepsize, x = linesearch.search(objective, man, x, desc_dir, cost,
+                                            -gradnorm**2)
 
             stop_reason = self._check_stopping_criterion(
                 time0, stepsize=stepsize, gradnorm=gradnorm, iter=iter)

--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -12,10 +12,10 @@ class SteepestDescent(Solver):
     steepestdescent.m from the manopt MATLAB package.
     """
 
-    def __init__(self, LineSearch=LineSearchBackTracking, *args, **kwargs):
+    def __init__(self, linesearch=LineSearchBackTracking(), *args, **kwargs):
         super(SteepestDescent, self).__init__(*args, **kwargs)
 
-        self.LineSearch = LineSearch
+        self.linesearch = linesearch
 
     # Function to solve optimisation problem using steepest descent.
     def solve(self, problem, x=None):
@@ -43,7 +43,7 @@ class SteepestDescent(Solver):
         objective = problem.cost
         gradient = problem.grad
 
-        linesearch = self.LineSearch()
+        linesearch = self.linesearch
 
         # If no starting point is specified, generate one at random.
         if x is None:


### PR DESCRIPTION
This allows changing line-search after solver has been setup. Also line
search must be passed as a class, which is then instantiated at the
start of solve(). Therefore any line search settings must be set as
static variables, rather than via the constructor. This is useful in
case a line searcher has variables that need to be reset each time
solve() is used (e.g. an iteration counter).

I think this approach is more consistent and more flexible than before.

Also changed name LineSearch to LineSearchBacktracking.