### PR TITLE
Sphere subspace intersection

### DIFF
--- a/pymanopt/manifolds/__init__.py
+++ b/pymanopt/manifolds/__init__.py
@@ -1,5 +1,6 @@
 from .grassmann import Grassmann
-from .sphere import Sphere
+from .sphere import (Sphere, SphereSubspaceIntersection,
+                     SphereSubspaceComplementIntersection)
 from .stiefel import Stiefel
 from .psd import PSDFixedRank, PSDFixedRankComplex, Elliptope, PositiveDefinite
 from .oblique import Oblique
@@ -7,6 +8,7 @@ from .euclidean import Euclidean, Symmetric
 from .product import Product
 from .fixed_rank import FixedRankEmbedded
 
-__all__ = ["Grassmann", "Sphere", "Stiefel", "PSDFixedRank",
+__all__ = ["Grassmann", "Sphere", "SphereSubspaceIntersection",
+           "SphereSubspaceComplementIntersection", "Stiefel", "PSDFixedRank",
            "PSDFixedRankComplex", "Elliptope", "PositiveDefinite", "Oblique",
            "Euclidean", "Product", "Symmetric", "FixedRankEmbedded"]

--- a/pymanopt/manifolds/sphere.py
+++ b/pymanopt/manifolds/sphere.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+import warnings
+
 import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd
@@ -127,6 +129,10 @@ class SphereSubspaceIntersection(Sphere):
                     "Number of rows in U does not match dimension of the "
                     "ambient space.")
             self._configure_manifold(U)
+
+        if self.dim == 0:
+            warnings.warn("Manifold only consists of isolated points when "
+                          "subspace is 1-dimensional.")
 
     def _configure_manifold(self, U):
         Q, _ = la.qr(U)

--- a/pymanopt/manifolds/sphere.py
+++ b/pymanopt/manifolds/sphere.py
@@ -147,7 +147,8 @@ class SphereSubspaceIntersection(Sphere):
         return self._subspace_dimension - 1
 
     def proj(self, X, H):
-        return H - self.inner(None, X, H) * self._subspace_projector.dot(X)
+        Y = super(SphereSubspaceIntersection, self).proj(X, H)
+        return self._subspace_projector.dot(Y)
 
     egrad2rgrad = proj
 

--- a/tests/test_manifold_sphere.py
+++ b/tests/test_manifold_sphere.py
@@ -168,12 +168,11 @@ class TestSphereSubspaceIntersectionManifold(unittest.TestCase):
 
     def test_proj(self):
         h = rnd.randn(self.n)
-        h = np.zeros(self.n)
         x = self.man.rand()
         p = self.man.proj(x, h)
         # Since the manifold is 0-dimensional, the tangent at each point is
         # simply the 0-dimensional space {0}.
-        np_testing.assert_allclose(p, np.zeros(self.n))
+        np_testing.assert_array_almost_equal(p, np.zeros(self.n))
 
     def test_dim_1(self):
         U = np.zeros((3, 2))
@@ -216,6 +215,11 @@ class TestSphereSubspaceComplementIntersectionManifold(unittest.TestCase):
 
     def test_proj(self):
         h = rnd.randn(self.n)
+        x = self.man.rand()
+        p = self.man.proj(x, h)
+        # Since the manifold is 0-dimensional, the tangent at each point is
+        # simply the 0-dimensional space {0}.
+        np_testing.assert_array_almost_equal(p, np.zeros(self.n))
 
     def test_dim_rand(self):
         n = 100

--- a/tests/test_manifold_sphere.py
+++ b/tests/test_manifold_sphere.py
@@ -221,6 +221,19 @@ class TestSphereSubspaceComplementIntersectionManifold(unittest.TestCase):
         # simply the 0-dimensional space {0}.
         np_testing.assert_array_almost_equal(p, np.zeros(self.n))
 
+    def test_dim_1(self):
+        U = np.zeros((3, 1))
+        U[-1, -1] = 1
+        man = SphereSubspaceComplementIntersection(3, U)
+        # U spans the z-axis with its orthogonal complement being the x-y
+        # plane, therefore the manifold consists of the 1-sphere in the x-y
+        # plane, and has dimension 1.
+        self.assertEqual(man.dim, 1)
+        # Check if a random element from the manifold has vanishing
+        # z-component.
+        x = man.rand()
+        np_testing.assert_almost_equal(x[-1], 0)
+
     def test_dim_rand(self):
         n = 100
         U = rnd.randn(n, n // 3)


### PR DESCRIPTION
This PR adds the manifold of unit 2-norm vectors intersecting a subspace spanned by the columns of a user-supplied matrix, as well as the manifold of unit 2-norm vectors which are orthogonal to the subspace spanned by the columns of said matrix. The class names aren't exactly concise, but it was the best I could come up with so far. I'm open to suggestions though.

There aren't any unit tests yet, but considering the new classes inherit most of their properties from the sphere manifold, writing some basic tests for the few modified methods shouldn't take too long. I'll try to get this done by the end of the week.