### PR TITLE
Respect dtype in tensorflow hessian

### DIFF
--- a/pymanopt/tools/autodiff/_tensorflow.py
+++ b/pymanopt/tools/autodiff/_tensorflow.py
@@ -78,7 +78,7 @@ class TensorflowBackend(Backend):
     @assert_backend_available
     def compute_hessian(self, objective, argument):
         if not isinstance(argument, list):
-            argA = tf.Variable(tf.zeros(tf.shape(argument)))
+            argA = tf.zeros_like(argument)
             tfhess = _hessian_vector_product(objective, [argument], [argA])
 
             def hess(x, a):
@@ -86,8 +86,7 @@ class TensorflowBackend(Backend):
                 return self._session.run(tfhess[0], feed_dict)
 
         else:
-            argA = [tf.Variable(tf.zeros(tf.shape(arg)))
-                    for arg in argument]
+            argA = [tf.zeros_like(arg) for arg in argument]
             tfhess = _hessian_vector_product(objective, argument, argA)
 
             def hess(x, a):

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import numpy.random as rnd
 import numpy.testing as np_testing
-from numpy import float32
+from numpy import float32, float64
 
 import tensorflow as tf
 
@@ -14,11 +14,11 @@ class TestVector(unittest.TestCase):
     def setUp(self):
         n = self.n = 15
 
-        self.X = X = tf.Variable(tf.zeros([n]))
+        self.X = X = tf.Variable(tf.zeros([n], dtype=float64))
         self.cost = tf.exp(tf.reduce_sum(X**2))
 
-        Y = self.Y = rnd.randn(n).astype(float32) * 1e-3
-        A = self.A = rnd.randn(n).astype(float32) * 1e-3
+        Y = self.Y = rnd.randn(n) * 1e-3
+        A = self.A = rnd.randn(n) * 1e-3
 
         # Calculate correct cost and grad...
         self.correct_cost = np.exp(np.sum(Y ** 2))


### PR DESCRIPTION
Hessian argA dtype defaulted to float32.
Change one tensorflow test to use float64, to verify.