### PR TITLE
Workaround for SciPy solve_lyapunov bug

### DIFF
--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -6,7 +6,11 @@ import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd
 import scipy as sp
-from scipy.linalg import solve_continuous_lyapunov as lyap
+# Workaround for SciPy bug: https://github.com/scipy/scipy/pull/8082
+try:
+    from scipy.linalg import solve_continuous_lyapunov as lyap
+except ImportError:
+    from scipy.linalg import solve_lyapunov as lyap
 
 from pymanopt.manifolds.manifold import Manifold
 from pymanopt.tools.multi import multiprod, multitransp, multisym, multilog

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -6,7 +6,7 @@ import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd
 import scipy as sp
-from scipy.linalg import solve_lyapunov as lyap
+from scipy.linalg import solve_continuous_lyapunov as lyap
 
 from pymanopt.manifolds.manifold import Manifold
 from pymanopt.tools.multi import multiprod, multitransp, multisym, multilog


### PR DESCRIPTION
In SciPy 1.0.0, `scipy.linalg.solve_lyapunov` is not importable. See
this PR for details:
https://github.com/scipy/scipy/pull/8082

Signed-off-by: Mihai Capotă <mihai@mihaic.ro>