### PR TITLE
Add fallback import for scipy.linag.solve_lyapunov

### DIFF
--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -6,7 +6,10 @@ import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd
 import scipy as sp
-from scipy.linalg import solve_lyapunov as lyap
+try:
+    from scipy.linalg import solve_lyapunov as lyap
+except ImportError:
+    from scipy.linalg import solve_continuous_lyapunov as lyap
 
 from pymanopt.manifolds.manifold import Manifold
 from pymanopt.tools.multi import multiprod, multitransp, multisym, multilog


### PR DESCRIPTION
Scipy moved the function in their 1.0.0 release.  The release notes claim
"In order to have consistent function names, the function
 scipy.linalg.solve_lyapunov is renamed to
 scipy.linalg.solve_continuous_lyapunov. The old name is kept for
 backwards-compatibility."  This not not appear to
be true, as importing pymanopt with the new version of scipy (as installable
through pip) causes import errors.  This fix works with either version.

Signed-off-by: Jordan Yoder <jordan.yoder@gmail.com>