### PR TITLE
Explicitly convert step size parameters to float from numpy.float64.

### DIFF
--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -200,6 +200,7 @@ class ConjugateGradient(Solver):
                         "Unknown beta_type %s. Should be one of %s." % (
                             self._beta_type, types))
 
+                beta = float(beta)
                 desc_dir = -Pnewgrad + beta * desc_dir
 
             # Update the necessary variables for the next iteration.

--- a/pymanopt/solvers/particle_swarm.py
+++ b/pymanopt/solvers/particle_swarm.py
@@ -131,6 +131,7 @@ class ParticleSwarm(Solver):
             # Compute the inertia factor which we linearly decrease from 0.9 to
             # 0.4 from iter = 0 to iter = maxiter.
             w = 0.4 + 0.5 * (1 - iter / self._maxiter)
+            w = float(w)
 
             # Compute the velocities.
             for i, xi in enumerate(x):

--- a/pymanopt/solvers/trust_regions.py
+++ b/pymanopt/solvers/trust_regions.py
@@ -450,6 +450,7 @@ class TrustRegions(Solver):
 
             # Note that if d_Hd == 0, we will exit at the next "if" anyway.
             alpha = z_r / d_Hd
+            alpha = float(alpha)
             # <neweta,neweta>_P =
             # <eta,eta>_P + 2*alpha*<eta,delta>_P + alpha*alpha*<delta,delta>_P
             e_Pe_new = e_Pe + 2 * alpha * e_Pd + alpha * alpha * d_Pd
@@ -464,6 +465,7 @@ class TrustRegions(Solver):
                 tau = ((-e_Pd +
                         np.sqrt(e_Pd * e_Pd +
                                 d_Pd * (Delta ** 2 - e_Pe))) / d_Pd)
+                tau = float(tau)
 
                 eta = eta + tau * delta
 
@@ -543,6 +545,7 @@ class TrustRegions(Solver):
 
             # Compute new search direction
             beta = z_r / zold_rold
+            beta = float(beta)
             delta = -z + beta * delta
 
             # Update new P-norms and P-dots [CGT2000, eq. 7.5.6 & 7.5.7].


### PR DESCRIPTION
Explicitly convert step size parameters to `float` from `numpy.float64` to prevent type exceptions. This fixes https://github.com/pymanopt/pymanopt/issues/49.