### PR TITLE
Switch linter to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # Use openblas to fix a theano error (hacky); see http://stackoverflow.com/questions/11987325/theano-fails-due-to-numpy-fortran-mixup-under-ubuntu
   - conda create --name conda-env-python$TRAVIS_PYTHON_VERSION --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose libgfortran six wheel
   - source activate conda-env-python$TRAVIS_PYTHON_VERSION
-  - pip install pep8
+  - pip install flake8
   - pip install coveralls
   - pip install autograd
   - pip install theano
@@ -48,7 +48,7 @@ install:
 
 script:
   - nosetests ./tests --nologcapture --verbosity=2 --with-coverage --cover-package=pymanopt
-  - pep8 examples pymanopt tests setup.py
+  - flake8 examples pymanopt tests setup.py
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 sudo: required
 

--- a/examples/rotations_example.py
+++ b/examples/rotations_example.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pymanopt import Problem
-from pymanopt.solvers import TrustRegions, SteepestDescent
+from pymanopt.solvers import TrustRegions
 from pymanopt.manifolds import Rotations
 
 n = 3

--- a/pymanopt/manifolds/complexcircle.py
+++ b/pymanopt/manifolds/complexcircle.py
@@ -1,7 +1,5 @@
 from __future__ import division
 
-import warnings
-
 import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -56,9 +56,9 @@ class PositiveDefinite(Manifold):
         # efficient way to compute this!
         c = np.linalg.cholesky(x)
         c_inv = np.linalg.inv(c)
-        l = multilog(multiprod(multiprod(c_inv, y), multitransp(c_inv)),
-                     pos_def=True)
-        return la.norm(multiprod(multiprod(c, l), c_inv))
+        logm = multilog(multiprod(multiprod(c_inv, y), multitransp(c_inv)),
+                        pos_def=True)
+        return la.norm(multiprod(multiprod(c, logm), c_inv))
 
     def inner(self, x, u, v):
         return np.tensordot(la.solve(x, u), la.solve(x, v), axes=x.ndim)
@@ -133,9 +133,9 @@ class PositiveDefinite(Manifold):
     def log(self, x, y):
         c = la.cholesky(x)
         c_inv = la.inv(c)
-        l = multilog(multiprod(multiprod(c_inv, y), multitransp(c_inv)),
-                     pos_def=True)
-        return multiprod(multiprod(c, l), multitransp(c))
+        logm = multilog(multiprod(multiprod(c_inv, y), multitransp(c_inv)),
+                        pos_def=True)
+        return multiprod(multiprod(c, logm), multitransp(c))
 
     def pairmean(self, X, Y):
         '''

--- a/pymanopt/tools/multi.py
+++ b/pymanopt/tools/multi.py
@@ -59,9 +59,9 @@ def multilog(A, pos_def=False):
     # Computes the logm of each matrix in an array containing k positive
     # definite matrices. This is much faster than scipy.linalg.logm even
     # for a single matrix. Could potentially be improved further.
-    l, v = np.linalg.eigh(A)
-    l = np.expand_dims(np.log(l), axis=-1)
-    return multiprod(v, l * multitransp(v))
+    w, v = np.linalg.eigh(A)
+    w = np.expand_dims(np.log(w), axis=-1)
+    return multiprod(v, w * multitransp(v))
 
 
 def multiexp(A, sym=False):
@@ -70,6 +70,6 @@ def multiexp(A, sym=False):
 
     # Compute the expm of each matrix in an array of k symmetric matrices.
     # Sometimes faster than scipy.linalg.expm even for a single matrix.
-    l, v = np.linalg.eigh(A)
-    l = np.expand_dims(np.exp(l), axis=-1)
-    return multiprod(v, l * multitransp(v))
+    w, v = np.linalg.eigh(A)
+    w = np.expand_dims(np.exp(w), axis=-1)
+    return multiprod(v, w * multitransp(v))

--- a/tests/test_manifold_positive_definite.py
+++ b/tests/test_manifold_positive_definite.py
@@ -29,8 +29,8 @@ class TestSinglePositiveDefiniteManifold(unittest.TestCase):
         np_testing.assert_allclose(x, multisym(x))
 
         # Check positivity of eigenvalues
-        l = la.eigvalsh(x)
-        assert (l > [0]).all()
+        w = la.eigvalsh(x)
+        assert (w > [0]).all()
 
     def test_exp(self):
         man = self.man
@@ -145,8 +145,8 @@ class TestMultiPositiveDefiniteManifold(unittest.TestCase):
         np_testing.assert_allclose(x, multisym(x))
 
         # Check positivity of eigenvalues
-        l = la.eigvalsh(x)
-        assert (l > [[0]]).all()
+        w = la.eigvalsh(x)
+        assert (w > [[0]]).all()
 
     def test_randvec(self):
         # Just test that randvec returns an element of the tangent space
@@ -192,8 +192,8 @@ class TestMultiPositiveDefiniteManifold(unittest.TestCase):
         np_testing.assert_allclose(y, multisym(y))
 
         # Check positivity of eigenvalues
-        l = la.eigvalsh(y)
-        assert (l > [[0]]).all()
+        w = la.eigvalsh(y)
+        assert (w > [[0]]).all()
 
         u = u * 1e-6
         np_testing.assert_allclose(man.retr(x, u), x + u)

--- a/tests/test_manifold_sphere.py
+++ b/tests/test_manifold_sphere.py
@@ -154,7 +154,7 @@ class TestSphereSubspaceIntersectionManifold(unittest.TestCase):
         # passing through (1, 1) / sqrt(2). This creates a 0-dimensional
         # manifold as it only consits of isolated points in R^2.
         self.U = np.ones((self.n, 1)) / np.sqrt(2)
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True):
             self.man = SphereSubspaceIntersection(self.n, self.U)
 
     def test_dim(self):
@@ -202,7 +202,7 @@ class TestSphereSubspaceComplementIntersectionManifold(unittest.TestCase):
         # a 0-dimensional manifold as it only consits of isolated points in
         # R^2.
         self.U = np.ones((self.n, 1)) / np.sqrt(2)
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True):
             self.man = SphereSubspaceComplementIntersection(self.n, self.U)
 
     def test_dim(self):

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -75,13 +75,13 @@ class TestMulti(unittest.TestCase):
 
     def test_multilog(self):
         A = np.zeros((self.k, self.m, self.m))
-        l = np.zeros((self.k, self.m, self.m))
+        L = np.zeros((self.k, self.m, self.m))
         for i in range(self.k):
             a = np.diag(rnd.rand(self.m))
             q, r = la.qr(rnd.randn(self.m, self.m))
             A[i] = q.dot(a.dot(q.T))
-            l[i] = logm(A[i])
-        np_testing.assert_allclose(multilog(A, pos_def=True), l)
+            L[i] = logm(A[i])
+        np_testing.assert_allclose(multilog(A, pos_def=True), L)
 
     def test_multiexp_singlemat(self):
         # A is a positive definite matrix


### PR DESCRIPTION
It seems the pep8 package is gonna become deprecated in the near future. This PR therefore switches the linter to flake8 and fixes the new warnings due to this change. In particular, pycodestyle rules suggest not to use 'l', 'O' or 'I' which we violated in a couple of places (cf. https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes).

This PR additionally runs integration tests for python 3.6 which has been out for a while so it's about time we checked compatibility.