### PR TITLE
Rework autodiff implementation

### DIFF
--- a/examples/dominant_eigenvector_pytorch.py
+++ b/examples/dominant_eigenvector_pytorch.py
@@ -1,0 +1,61 @@
+import numpy as np
+import numpy.random as rnd
+import numpy.linalg as la
+import torch
+
+from pymanopt import Problem
+from pymanopt.tools import decorators
+from pymanopt.manifolds import Sphere
+from pymanopt.solvers import TrustRegions
+
+
+def dominant_eigenvector(A):
+    """
+    Returns the dominant eigenvector of the symmetric matrix A.
+
+    Note: For the same A, this should yield the same as the dominant invariant
+    subspace example with p = 1.
+    """
+    m, n = A.shape
+    assert m == n, "matrix must be square"
+    assert np.allclose(np.sum(A - A.T), 0), "matrix must be symmetric"
+
+    manifold = Sphere(n)
+    solver = TrustRegions()
+
+    A_ = torch.from_numpy(A)
+
+    @decorators.pytorch
+    def cost(x):
+        return -x.matmul(A_.matmul(x))
+
+    problem = Problem(manifold=manifold, cost=cost)
+    xopt = solver.solve(problem)
+    return xopt.squeeze()
+
+
+if __name__ == "__main__":
+    # Generate random problem data.
+    n = 128
+    A = rnd.randn(n, n)
+    A = 0.5 * (A + A.T)
+
+    # Calculate the actual solution by a conventional eigenvalue decomposition.
+    w, v = la.eig(A)
+    x = v[:, np.argmax(w)]
+
+    # Solve the problem with pymanopt.
+    xopt = dominant_eigenvector(A)
+
+    # Make sure both vectors have the same direction. Both are valid
+    # eigenvectors, of course, but for comparison we need to get rid of the
+    # ambiguity.
+    if np.sign(x[0]) != np.sign(xopt[0]):
+        xopt = -xopt
+
+    # Print information about the solution.
+    print('')
+    print("l2-norm of x: %f" % la.norm(x))
+    print("l2-norm of xopt: %f" % la.norm(xopt))
+    print("solution found: %s" % np.allclose(x, xopt, rtol=1e-3))
+    print("l2-error: %f" % la.norm(x - xopt))

--- a/examples/linreg.py
+++ b/examples/linreg.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 
 from pymanopt import Problem
+from pymanopt.tools import decorators
 from pymanopt.solvers import TrustRegions
 from pymanopt.manifolds import Euclidean
 
@@ -11,6 +12,7 @@ if __name__ == "__main__":
     Y = np.random.randint(-5, 5, (1, 200))
 
     # Cost function is the squared error
+    @decorators.autograd
     def cost(w):
         return np.sum(np.sum((Y - np.dot(w.T, X))**2))
 

--- a/examples/linreg_multiple_autograd.py
+++ b/examples/linreg_multiple_autograd.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 
 from pymanopt import Problem
+from pymanopt.tools import decorators
 from pymanopt.manifolds import Euclidean
 from pymanopt.solvers import TrustRegions
 
@@ -10,6 +11,7 @@ if __name__ == "__main__":
     X = np.zeros((200, 3))
     y = np.zeros((200, 3))
 
+    @decorators.autograd
     def cost(w):
         return np.sum((y - np.dot(X, w)) ** 2)
     # A solver that involves the hessian

--- a/examples/low_rank_matrix_approximation.py
+++ b/examples/low_rank_matrix_approximation.py
@@ -1,6 +1,8 @@
-from pymanopt.manifolds import FixedRankEmbedded
 import autograd.numpy as np
+
 from pymanopt import Problem
+from pymanopt.tools import decorators
+from pymanopt.manifolds import FixedRankEmbedded
 from pymanopt.solvers import ConjugateGradient
 
 # Let A be a (5 x 4) matrix to be approximated
@@ -20,6 +22,7 @@ manifold = FixedRankEmbedded(A.shape[0], A.shape[1], k)
 # (b) Definition of a cost function (here using autograd.numpy)
 #       Note that the cost must be defined in terms of u, s and vt, where
 #       X = u * diag(s) * vt.
+@decorators.autograd
 def cost(usv):
     delta = .5
     u = usv[0]

--- a/examples/optlog_example.py
+++ b/examples/optlog_example.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 
 from pymanopt import Problem
+from pymanopt.tools import decorators
 from pymanopt.solvers import SteepestDescent
 from pymanopt.manifolds import Stiefel
 
@@ -11,6 +12,7 @@ if __name__ == "__main__":
     X = np.diag([3, 2, 1]).dot(np.random.randn(3, 200))
 
     # Cost function is the squared reconstruction error
+    @decorators.autograd
     def cost(w):
         return np.sum(np.sum((X - np.dot(w, np.dot(w.T, X)))**2))
 

--- a/examples/packing_on_the_sphere.py
+++ b/examples/packing_on_the_sphere.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 
 from pymanopt import Problem
+from pymanopt.tools import decorators
 from pymanopt.manifolds import Elliptope
 from pymanopt.solvers import ConjugateGradient
 
@@ -9,6 +10,7 @@ def packing_on_the_sphere(n, k, epsilon):
     manifold = Elliptope(n, k)
     solver = ConjugateGradient(mingradnorm=1e-8, maxiter=1e5)
 
+    @decorators.autograd
     def cost(X):
         Y = np.dot(X, X.T)
         # Shift the exponentials by the maximum value to reduce numerical

--- a/examples/pca_autograd.py
+++ b/examples/pca_autograd.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 
 from pymanopt import Problem
+from pymanopt.tools import decorators
 from pymanopt.solvers import TrustRegions
 from pymanopt.manifolds import Stiefel
 
@@ -10,6 +11,7 @@ if __name__ == "__main__":
     X = np.diag([3, 2, 1]).dot(np.random.randn(3, 200))
 
     # Cost function is the squared reconstruction error
+    @decorators.autograd
     def cost(w):
         return np.sum(np.sum((X - np.dot(w, np.dot(w.T, X)))**2))
 

--- a/examples/regression_offset_autograd.py
+++ b/examples/regression_offset_autograd.py
@@ -1,6 +1,7 @@
 import autograd.numpy as np
 
 from pymanopt import Problem
+from pymanopt.tools import decorators
 from pymanopt.solvers import TrustRegions
 from pymanopt.manifolds import Euclidean, Product
 
@@ -13,6 +14,7 @@ if __name__ == "__main__":
     # Note, weights is a tuple/list containing both weight vector w and bias b.
     # This is necessary for autograd to calculate the gradient w.r.t. both
     # arguments in one go.
+    @decorators.autograd
     def cost(weights):
         w = weights[0]
         b = weights[1]

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -4,8 +4,7 @@ object to feed to one of the solvers.
 """
 from __future__ import print_function
 
-from pymanopt.tools.autodiff import (AutogradBackend, TheanoBackend,
-                                     TensorflowBackend)
+from pymanopt.tools.autodiff import Function
 
 
 class Problem(object):
@@ -50,18 +49,19 @@ class Problem(object):
     """
     def __init__(self, manifold, cost, egrad=None, ehess=None, grad=None,
                  hess=None, arg=None, precon=None, verbosity=2):
-        self.manifold = manifold
-        # We keep a reference to the original cost function in case we want to
-        # call the `prepare` method twice (for instance, after switching from
-        # a first- to second-order method).
         self._cost = None
+        self._egrad = None
+        self._ehess = None
+        self._grad = None
+        self._hess = None
+
+        self.manifold = manifold
         self._original_cost = cost
-        self._egrad = egrad
-        self._ehess = ehess
-        self._grad = grad
-        self._hess = hess
+        self._original_egrad = egrad
+        self._original_ehess = ehess
+        self._original_grad = grad
+        self._original_hess = hess
         self._arg = arg
-        self._backend = None
 
         if precon is None:
             def precon(x, d):
@@ -70,85 +70,56 @@ class Problem(object):
 
         self.verbosity = verbosity
 
-        self._backends = list(
-            filter(lambda b: b.is_available(), [
-                TheanoBackend(),
-                AutogradBackend(),
-                TensorflowBackend()
-                ]))
-        self._backend = None
-
-    @property
-    def backend(self):
-        if self._backend is None:
-            for backend in self._backends:
-                if backend.is_compatible(self._original_cost, self._arg):
-                    self._backend = backend
-                    break
-            else:
-                backend_names = [str(backend) for backend in self._backends]
-                if self.verbosity >= 1:
-                    print(backend_names)
-                raise ValueError(
-                    "Cannot determine autodiff backend from cost function of "
-                    "type `{:s}`. Available backends are: {:s}".format(
-                        self._original_cost.__class__.__name__,
-                        ", ".join(backend_names)))
-        return self._backend
-
     @property
     def cost(self):
-        if (self._cost is None and callable(self._original_cost) and
-                not AutogradBackend().is_available()):
-            self._cost = self._original_cost
-
-        elif self._cost is None:
-            if self.verbosity >= 1:
-                print("Compiling cost function...")
-            self._cost = self.backend.compile_function(self._original_cost,
-                                                       self._arg)
-
+        if self._cost is None:
+            self._cost = Function(self._original_cost, self._arg)
         return self._cost
+
+    # FIXME: Since _arg is passed to the problem class, we can't have different
+    #        types of functions/call graphs for cost, gradients and Hessians.
 
     @property
     def egrad(self):
         if self._egrad is None:
-            if self.verbosity >= 1:
-                print("Computing gradient of cost function...")
-            egrad = self.backend.compute_gradient(self._original_cost,
-                                                  self._arg)
-            self._egrad = egrad
+            if self._original_egrad is None:
+                self._egrad = self.cost.compute_gradient()
+            else:
+                self._egrad = Function(self._original_egrad, self._arg)
         return self._egrad
 
     @property
     def grad(self):
         if self._grad is None:
-            # Explicit access forces computation/compilation if necessary.
-            egrad = self.egrad
+            if self._original_grad is None:
+                egrad = self.egrad
 
-            def grad(x):
-                return self.manifold.egrad2rgrad(x, egrad(x))
-            self._grad = grad
+                def grad(x):
+                    return self.manifold.egrad2rgrad(x, egrad(x))
+                self._grad = Function(grad)
+            else:
+                self._grad = Function(self._original_grad, self._arg)
         return self._grad
 
     @property
     def ehess(self):
         if self._ehess is None:
-            if self.verbosity >= 1:
-                print("Computing Hessian of cost function...")
-            ehess = self.backend.compute_hessian(self._original_cost,
-                                                 self._arg)
-            self._ehess = ehess
+            if self._original_ehess is None:
+                self._ehess = self.cost.compute_hessian()
+            else:
+                self._ehess = Function(self._original_ehess, self._arg)
         return self._ehess
 
     @property
     def hess(self):
         if self._hess is None:
-            # Explicit access forces computation if necessary.
-            ehess = self.ehess
+            if self._original_hess is None:
+                ehess = self.ehess
 
-            def hess(x, a):
-                return self.manifold.ehess2rhess(
-                    x, self.egrad(x), ehess(x, a), a)
-            self._hess = hess
+                def hess(x, a):
+                    return self.manifold.ehess2rhess(
+                        x, self.egrad(x), ehess(x, a), a)
+                self._hess = Function(hess)
+            else:
+                self._hess = Function(self._original_hess, self._arg)
         return self._hess

--- a/pymanopt/tools/autodiff/__init__.py
+++ b/pymanopt/tools/autodiff/__init__.py
@@ -28,7 +28,8 @@ class Function(object):
             if not backend.is_compatible(function, argument):
                 raise ValueError("Backend `{:s}' not compatible with cost "
                                  "function of type `{:s}'".format(
-                                     str(backend), function.__class__.__name__))
+                                     str(backend),
+                                     function.__class__.__name__))
         else:
             # We can only auto-detect theano and tensorflow since autograd and
             # pytorch functions are regular callables. In case we get passed a

--- a/pymanopt/tools/autodiff/__init__.py
+++ b/pymanopt/tools/autodiff/__init__.py
@@ -1,7 +1,12 @@
-from ._theano import TheanoBackend
-
+from ._callable import CallableBackend
 from ._autograd import AutogradBackend
-
+from ._pytorch import PyTorchBackend
+from ._theano import TheanoBackend
 from ._tensorflow import TensorflowBackend
+
+_BACKENDS = (CallableBackend, AutogradBackend, PyTorchBackend, TheanoBackend,
+             TensorflowBackend)
+__all__ = [Backend.__name__ for Backend in _BACKENDS]
+
 
 __all__ = ["TheanoBackend", "AutogradBackend", "TensorflowBackend"]

--- a/pymanopt/tools/autodiff/__init__.py
+++ b/pymanopt/tools/autodiff/__init__.py
@@ -9,4 +9,71 @@ _BACKENDS = (CallableBackend, AutogradBackend, PyTorchBackend, TheanoBackend,
 __all__ = [Backend.__name__ for Backend in _BACKENDS]
 
 
-__all__ = ["TheanoBackend", "AutogradBackend", "TensorflowBackend"]
+class Function(object):
+    def __init__(self, function, argument=None):
+        if isinstance(function, Function):
+            raise ValueError("Cannot wrap Function instance in Function")
+        self._function = function
+        self._arg = argument
+
+        self._backend = self._determine_backend(function, argument)
+        self._compile()
+
+    @staticmethod
+    def _determine_backend(function, argument):
+        backend = None
+
+        if hasattr(function, "backend"):
+            backend = function.backend
+            if not backend.is_compatible(function, argument):
+                raise ValueError("Backend `{:s}' not compatible with cost "
+                                 "function of type `{:s}'".format(
+                                     str(backend), function.__class__.__name__))
+        else:
+            # We can only auto-detect theano and tensorflow since autograd and
+            # pytorch functions are regular callables. In case we get passed a
+            # callable without the 'backend' attribute set as checked above,
+            # we therefore default to the canonical backend.
+            if callable(function):
+                backend = CallableBackend()
+            else:
+                for backend in [TheanoBackend(), TensorflowBackend()]:
+                    if (backend.is_available() and
+                            backend.is_compatible(function, argument)):
+                        break
+        if backend is None:
+            # TODO: Add a static .name attribute to backend classes instead so
+            #       we don't have to instantiate every backend here.
+            backend_names = [str(Backend()) for Backend in _BACKENDS]
+            raise ValueError(
+                    "Cannot determine autodiff backend from cost function of "
+                    "type `{:s}`. Available backends are: {:s}".format(
+                        function.__class__.__name__, ", ".join(backend_names)))
+        return backend
+
+    def _compile(self):
+        assert self._backend is not None
+        self._compiled_function = self._backend.compile_function(
+            self._function, self._arg)
+
+    def _perform_differentiation(self, attr):
+        assert self._backend is not None
+        if isinstance(self._backend, CallableBackend):
+            raise ValueError("CallableBackend does not support automatic "
+                             "differentiation")
+        method = getattr(self._backend, attr)
+        derivative = method(self._function, self._arg)
+        # Whatever the backend, the result of a call to an automatic
+        # differentation routine will be a regular callable which we cannot
+        # autodiff anymore. We therefore don't bother passing along self._arg.
+        return Function(derivative)
+
+    def compute_gradient(self):
+        return self._perform_differentiation("compute_gradient")
+
+    def compute_hessian(self):
+        return self._perform_differentiation("compute_hessian")
+
+    def __call__(self, *args, **kwargs):
+        assert self._compiled_function is not None
+        return self._compiled_function(*args, **kwargs)

--- a/pymanopt/tools/autodiff/_autograd.py
+++ b/pymanopt/tools/autodiff/_autograd.py
@@ -2,11 +2,12 @@
 Module containing functions to differentiate functions using autograd.
 """
 try:
+    import autograd
+except ImportError:
+    autograd = None
+else:
     import autograd.numpy as np
     from autograd import grad
-except ImportError:
-    np = None
-    grad = None
 
 from ._backend import Backend, assert_backend_available
 
@@ -15,7 +16,8 @@ class AutogradBackend(Backend):
     def __str__(self):
         return "autograd"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return np is not None and grad is not None
 
     @assert_backend_available
@@ -25,11 +27,10 @@ class AutogradBackend(Backend):
     @assert_backend_available
     def compile_function(self, objective, argument):
         def func(x):
-            if type(x) in (list, tuple):
-                return objective([np.array(xi) for xi in x])
+            if isinstance(x, (list, tuple)):
+                return objective(list(map(np.array, x)))
             else:
                 return objective(np.array(x))
-
         return func
 
     @assert_backend_available
@@ -43,8 +44,8 @@ class AutogradBackend(Backend):
         # Sometimes x will be some custom type, e.g. with the FixedRankEmbedded
         # manifold. Therefore cast it to a numpy.array.
         def gradient(x):
-            if type(x) in (list, tuple):
-                return g([np.array(xi) for xi in x])
+            if isinstance(x, (list, tuple)):
+                return g(list(map(np.array, x)))
             else:
                 return g(np.array(x))
         return gradient

--- a/pymanopt/tools/autodiff/_backend.py
+++ b/pymanopt/tools/autodiff/_backend.py
@@ -20,7 +20,7 @@ class Backend(object):
 
     compile_function = compute_gradient = compute_hessian = __id
 
-    def __false(self):
+    def __false(*args, **kwargs):
         return False
 
     is_available = is_compatible = __false

--- a/pymanopt/tools/autodiff/_callable.py
+++ b/pymanopt/tools/autodiff/_callable.py
@@ -1,0 +1,25 @@
+from ._backend import Backend, assert_backend_available
+
+
+class CallableBackend(Backend):
+    def __str__(self):
+        return "callable"
+
+    @staticmethod
+    def is_available():
+        return True
+
+    @assert_backend_available
+    def is_compatible(self, objective, argument):
+        return callable(objective)
+
+    @assert_backend_available
+    def compile_function(self, objective, argument):
+        return objective
+
+    @assert_backend_available
+    def __not_implemented(self, objective, argument):
+        raise NotImplementedError("No autodiff support available for the "
+                                  "canonical backend")
+
+    compute_gradient = compute_hessian = __not_implemented

--- a/pymanopt/tools/autodiff/_pytorch.py
+++ b/pymanopt/tools/autodiff/_pytorch.py
@@ -28,6 +28,8 @@ class PyTorchBackend(Backend):
     def is_compatible(self, objective, argument):
         return callable(objective)
 
+    # TODO: Add support for product manifolds.
+
     @assert_backend_available
     def compile_function(self, objective, argument):
         def func(x):

--- a/pymanopt/tools/autodiff/_pytorch.py
+++ b/pymanopt/tools/autodiff/_pytorch.py
@@ -1,0 +1,75 @@
+"""
+Module containing functions to differentiate functions using pytorch.
+"""
+try:
+    import torch
+except ImportError:
+    torch = None
+else:
+    from torch import autograd
+
+from ._backend import Backend, assert_backend_available
+
+
+class PyTorchBackend(Backend):
+    def __str__(self):
+        return "pytorch"
+
+    @staticmethod
+    def is_available():
+        # XXX: PyTorch 0.4 unified the Tensor and Variable API. Higher-order
+        #      derivatives to compute Hessian-vector products were introduced
+        #      in 0.2 so we should make that the first supported version.
+        #      However, supporting both Tensor and Variable requires a bit more
+        #      work that we'll skip for now.
+        return torch is not None and torch.__version__ >= "0.4"
+
+    @assert_backend_available
+    def is_compatible(self, objective, argument):
+        return callable(objective)
+
+    @assert_backend_available
+    def compile_function(self, objective, argument):
+        def func(x):
+            # PyTorch unboxes scalars automatically, but we still need to get a
+            # numpy view of the data when "compiling" gradients or Hessians.
+            f = objective(torch.from_numpy(x))
+            try:
+                return f.numpy()
+            except AttributeError:
+                pass
+            return f
+        return func
+
+    @assert_backend_available
+    def compute_gradient(self, objective, argument):
+        def grad(x):
+            x = torch.from_numpy(x)
+            x.requires_grad_(True)
+            objective(x).backward()
+            g = x.grad
+            # See above.
+            try:
+                return g.numpy()
+            except AttributeError:
+                pass
+            return g
+        return grad
+
+    @assert_backend_available
+    def compute_hessian(self, objective, argument):
+        def hess(x, v):
+            x = torch.from_numpy(x)
+            v = torch.from_numpy(v)
+            x.requires_grad_(True)
+            fx = objective(x)
+            grad_fx, *_ = autograd.grad(fx, x, create_graph=True)
+            grad_fx.matmul(v).backward()
+            g = x.grad
+            # See above.
+            try:
+                return g.numpy()
+            except AttributeError:
+                pass
+            return g
+        return hess

--- a/pymanopt/tools/autodiff/_pytorch.py
+++ b/pymanopt/tools/autodiff/_pytorch.py
@@ -65,7 +65,7 @@ class PyTorchBackend(Backend):
             v = torch.from_numpy(v)
             x.requires_grad_(True)
             fx = objective(x)
-            grad_fx, *_ = autograd.grad(fx, x, create_graph=True)
+            grad_fx = autograd.grad(fx, x, create_graph=True)[0]
             grad_fx.matmul(v).backward()
             g = x.grad
             # See above.

--- a/pymanopt/tools/autodiff/_tensorflow.py
+++ b/pymanopt/tools/autodiff/_tensorflow.py
@@ -22,7 +22,8 @@ class TensorflowBackend(Backend):
     def __str__(self):
         return "tensorflow"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return tf is not None
 
     @assert_backend_available
@@ -42,12 +43,10 @@ class TensorflowBackend(Backend):
     @assert_backend_available
     def compile_function(self, objective, argument):
         if not isinstance(argument, list):
-
             def func(x):
                 feed_dict = {argument: x}
                 return self._session.run(objective, feed_dict)
         else:
-
             def func(x):
                 feed_dict = {i: d for i, d in zip(argument, x)}
                 return self._session.run(objective, feed_dict)
@@ -62,13 +61,10 @@ class TensorflowBackend(Backend):
         tfgrad = tf.gradients(objective, argument)
 
         if not isinstance(argument, list):
-
             def grad(x):
                 feed_dict = {argument: x}
                 return self._session.run(tfgrad[0], feed_dict)
-
         else:
-
             def grad(x):
                 feed_dict = {i: d for i, d in zip(argument, x)}
                 return self._session.run(tfgrad, feed_dict)
@@ -84,7 +80,6 @@ class TensorflowBackend(Backend):
             def hess(x, a):
                 feed_dict = {argument: x, argA: a}
                 return self._session.run(tfhess[0], feed_dict)
-
         else:
             argA = [tf.zeros_like(arg) for arg in argument]
             tfhess = _hessian_vector_product(objective, argument, argA)

--- a/pymanopt/tools/autodiff/_theano.py
+++ b/pymanopt/tools/autodiff/_theano.py
@@ -18,7 +18,8 @@ class TheanoBackend(Backend):
     def __str__(self):
         return "theano"
 
-    def is_available(self):
+    @staticmethod
+    def is_available():
         return theano is not None and T is not None
 
     @assert_backend_available

--- a/pymanopt/tools/decorators.py
+++ b/pymanopt/tools/decorators.py
@@ -1,0 +1,18 @@
+from .autodiff import AutogradBackend, PyTorchBackend
+
+
+def _verify_callable(f):
+    if not callable(f):
+        raise ValueError("{} is not callable".format(f.__name__))
+
+
+def autograd(f):
+    _verify_callable(f)
+    f.backend = AutogradBackend()
+    return f
+
+
+def pytorch(f):
+    _verify_callable(f)
+    f.backend = PyTorchBackend()
+    return f


### PR DESCRIPTION
As announced in #55, this PR slightly reworks the autodiff logic, and adds a PoC implementation of a pytorch backend as suggested in #52. The current PR should break most (if not all) backend-related tests due to the refactoring. Since this is an experimental rewrite, that's fine for now. Should we decide to merge this in the future, I'll go back and make sure the new backend logic has sufficient coverage/testing.