### PR TITLE
Added pytorch autograd backend (minimal changes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
   - pip install autograd
   - pip install theano
   - pip install tensorflow
-  - pip install torch 
+  - conda install pytorch -c pytorch
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,12 @@ install:
   # Use openblas to fix a theano error (hacky); see http://stackoverflow.com/questions/11987325/theano-fails-due-to-numpy-fortran-mixup-under-ubuntu
   - conda create --name conda-env-python$TRAVIS_PYTHON_VERSION --yes python=$TRAVIS_PYTHON_VERSION numpy scipy nose libgfortran six wheel
   - source activate conda-env-python$TRAVIS_PYTHON_VERSION
+  - conda install -y pytorch -c pytorch
   - pip install flake8
   - pip install coveralls
   - pip install autograd
   - pip install theano
   - pip install tensorflow
-  - conda install pytorch -c pytorch
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ install:
   - pip install autograd
   - pip install theano
   - pip install tensorflow
+  - pip install torch 
   - python setup.py install
 
 script:

--- a/examples/linreg_multiple_pytorch.py
+++ b/examples/linreg_multiple_pytorch.py
@@ -8,8 +8,8 @@ from pymanopt.solvers import TrustRegions
 
 if __name__ == "__main__":
     # Cost function is the squared reconstruction error
-    X = torch.zeros((200, 3))
-    y = torch.zeros((200, 3))
+    X = torch.from_numpy(np.zeros((200, 3)))
+    y = torch.from_numpy(np.zeros((200, 3)))
 
     def cost(w):
         return (y - X @ w).pow(2).sum()

--- a/examples/linreg_multiple_pytorch.py
+++ b/examples/linreg_multiple_pytorch.py
@@ -1,0 +1,38 @@
+import torch
+import numpy as np
+
+from pymanopt import Problem
+from pymanopt.manifolds import Euclidean
+from pymanopt.solvers import TrustRegions
+
+
+if __name__ == "__main__":
+    # Cost function is the squared reconstruction error
+    X = torch.zeros((200, 3))
+    y = torch.zeros((200, 3))
+
+    def cost(w):
+        return (y - X @ w).pow(2).sum()
+
+    # A solver that involves the hessian
+    solver = TrustRegions()
+
+    # R^3
+    manifold = Euclidean(3, 1)
+
+    # Create the problem with extra cost function arguments
+    problem = Problem(manifold=manifold, cost=cost, verbosity=0, arg=torch.Tensor())
+
+    # Solve 5 instances of the same type of problem for different data input
+    for k in range(0, 5):
+        # Generate random data
+        X = torch.from_numpy(np.random.randn(200, 3))
+        y = torch.from_numpy(np.random.randn(200, 1))
+
+        wopt = solver.solve(problem)
+        print('Run {}'.format(k+1))
+        print('Weights found by pymanopt (top) / '
+              'closed form solution (bottom)')
+        print(wopt)
+        print(np.linalg.inv(X.numpy().T.dot(X)).dot(X.numpy().T).dot(y))
+        print('')

--- a/examples/linreg_multiple_pytorch.py
+++ b/examples/linreg_multiple_pytorch.py
@@ -36,4 +36,3 @@ if __name__ == "__main__":
               'closed form solution (bottom)')
         print(wopt)
         print(np.linalg.inv(X.numpy().T.dot(X)).dot(X.numpy().T).dot(y))
-        print('')

--- a/examples/linreg_multiple_pytorch.py
+++ b/examples/linreg_multiple_pytorch.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     y = torch.from_numpy(np.zeros((200, 3)))
 
     def cost(w):
-        return (y - X @ w).pow(2).sum()
+        return (y - X.matmul(w)).pow(2).sum()
 
     # A solver that involves the hessian
     solver = TrustRegions()
@@ -21,7 +21,8 @@ if __name__ == "__main__":
     manifold = Euclidean(3, 1)
 
     # Create the problem with extra cost function arguments
-    problem = Problem(manifold=manifold, cost=cost, verbosity=0, arg=torch.Tensor())
+    problem = Problem(manifold=manifold, cost=cost,
+                      verbosity=0, arg=torch.Tensor())
 
     # Solve 5 instances of the same type of problem for different data input
     for k in range(0, 5):

--- a/examples/pca_pytorch.py
+++ b/examples/pca_pytorch.py
@@ -1,0 +1,29 @@
+import numpy as np
+import torch
+
+from pymanopt import Problem
+from pymanopt.solvers import TrustRegions
+from pymanopt.manifolds import Stiefel
+
+
+if __name__ == "__main__":
+    # Generate random data with highest variance in first 2 dimensions
+    X = torch.from_numpy( np.diag([3, 2, 1]).dot(np.random.randn(3, 200)) )
+
+    # Cost function is the squared reconstruction error
+    def cost(w):
+        return (X - w @ w.t() @ X).pow(2).sum()
+
+    # A solver that involves the hessian
+    solver = TrustRegions()
+
+    # Projection matrices onto a two dimensional subspace
+    manifold = Stiefel(3, 2)
+
+    # Solve the problem with pymanopt
+    problem = Problem(manifold=manifold, cost=cost, arg=torch.Tensor())
+    wopt = solver.solve(problem)
+
+    print('The following projection matrix was found to minimise '
+          'the squared reconstruction error: ')
+    print(wopt)

--- a/examples/pca_pytorch.py
+++ b/examples/pca_pytorch.py
@@ -8,11 +8,11 @@ from pymanopt.manifolds import Stiefel
 
 if __name__ == "__main__":
     # Generate random data with highest variance in first 2 dimensions
-    X = torch.from_numpy( np.diag([3, 2, 1]).dot(np.random.randn(3, 200)) )
+    X = torch.from_numpy(np.diag([3, 2, 1]).dot(np.random.randn(3, 200)))
 
     # Cost function is the squared reconstruction error
     def cost(w):
-        return (X - w @ w.t() @ X).pow(2).sum()
+        return (X - w.matmul(w.t()).matmul(X)).pow(2).sum()
 
     # A solver that involves the hessian
     solver = TrustRegions()

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -101,7 +101,7 @@ class Problem(object):
     def cost(self):
         if (self._cost is None and callable(self._original_cost) and
                 not AutogradBackend().is_available() and
-                not PytorchBackend().is_available() ):
+                not PytorchBackend().is_available()):
             self._cost = self._original_cost
 
         elif self._cost is None:

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -5,7 +5,7 @@ object to feed to one of the solvers.
 from __future__ import print_function
 
 from pymanopt.tools.autodiff import (AutogradBackend, TensorflowBackend,
-                                     TensorflowBackend, PytorchBackend)
+                                     TheanoBackend, PytorchBackend)
 
 
 class Problem(object):

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -100,7 +100,8 @@ class Problem(object):
     @property
     def cost(self):
         if (self._cost is None and callable(self._original_cost) and
-                not AutogradBackend().is_available()):
+                not AutogradBackend().is_available() and
+                not PytorchBackend().is_available() ):
             self._cost = self._original_cost
 
         elif self._cost is None:

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -5,7 +5,7 @@ object to feed to one of the solvers.
 from __future__ import print_function
 
 from pymanopt.tools.autodiff import (AutogradBackend, TheanoBackend,
-                                     TensorflowBackend)
+                                     TensorflowBackend, PytorchBackend)
 
 
 class Problem(object):
@@ -73,6 +73,7 @@ class Problem(object):
         self._backends = list(
             filter(lambda b: b.is_available(), [
                 TheanoBackend(),
+                PytorchBackend(),
                 AutogradBackend(),
                 TensorflowBackend()
                 ]))

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -4,7 +4,7 @@ object to feed to one of the solvers.
 """
 from __future__ import print_function
 
-from pymanopt.tools.autodiff import (AutogradBackend, TheanoBackend,
+from pymanopt.tools.autodiff import (AutogradBackend, TensorflowBackend,
                                      TensorflowBackend, PytorchBackend)
 
 

--- a/pymanopt/tools/autodiff/__init__.py
+++ b/pymanopt/tools/autodiff/__init__.py
@@ -6,4 +6,5 @@ from ._tensorflow import TensorflowBackend
 
 from ._pytorch import PytorchBackend
 
-__all__ = ["TheanoBackend", "PytorchBackend", "AutogradBackend", "TensorflowBackend"]
+__all__ = ["AutogradBackend", "PytorchBackend",
+           "TensorflowBackend", "TheanoBackend"]

--- a/pymanopt/tools/autodiff/__init__.py
+++ b/pymanopt/tools/autodiff/__init__.py
@@ -4,4 +4,6 @@ from ._autograd import AutogradBackend
 
 from ._tensorflow import TensorflowBackend
 
-__all__ = ["TheanoBackend", "AutogradBackend", "TensorflowBackend"]
+from ._pytorch import PytorchBackend
+
+__all__ = ["TheanoBackend", "PytorchBackend", "AutogradBackend", "TensorflowBackend"]

--- a/pymanopt/tools/autodiff/_pytorch.py
+++ b/pymanopt/tools/autodiff/_pytorch.py
@@ -1,0 +1,123 @@
+"""
+Module containing functions to differentiate functions using autograd.
+"""
+try:
+    import torch
+    import numpy as np
+except ImportError:
+    torch = None
+    np = None
+
+from ._backend import Backend, assert_backend_available
+
+
+# The pytorch tape-based automatic differentiation means
+# that one needs to compute the function to compute its gradient.
+# Alas manopt uses different functions to compute the cost,
+# its gradient, or its hessian. Therefore it is important to
+# cache previous computations with the same x.
+
+    
+class PytorchBackend(Backend):
+    def __str__(self):
+        return "pytorch"
+
+    def is_available(self):
+        return torch is not None and np is not None
+
+    @assert_backend_available
+    def is_compatible(self, objective, arg):
+        """
+        To select the pytorch backend, use 'Problem(manifold=..,cost=...,arg=torch.Tensor())'
+        The tensor passed as argument is used as a python object to cache recent calls
+        to the cost, egrad, or ehess functions
+        """
+        return callable(objective) and isinstance(arg,torch.Tensor) and arg.nelement()==0
+
+    @assert_backend_available
+    def _compile(self, objective, cache):
+        if hasattr(cache,'cost'):
+            return cache
+        cache.x = None   #  list with torch copies of input np.arrays
+        cache.ids = None #  list with ids of the input np.arrays passed to cost/egrad/ehess
+        cache.f = None   #  scalar tensor with cost function (with tree for grad computation)
+        cache.df = None  #  list of gradient tensors (with tree for hessian vector computation)
+        
+        def _astensor(x):
+            return x.detach() if isinstance(x,torch.Tensor) else torch.from_numpy(np.array(x))
+
+        def _asiterable(x):
+            return (x, True) if type(x) in (list,tuple) else ([x],False)
+        
+        def _notcached(x,cache):
+            if not cache.ids:
+                return True
+            if len(x) != len(cache.ids):
+                return True
+            for (xi,cachex,cacheid) in zip(x,cache.x,cache.ids):
+                if (id(xi) != cacheid):
+                    return True
+                if not (_astensor(xi) == _astensor(cachex)).all().item():
+                    return True
+            return False
+
+        def _updatex(x,cache):
+            if _notcached(x,cache):
+                cache.x = [_astensor(xi).clone().requires_grad_() for xi in x]
+                cache.ids = [id(xi) for xi in x]
+                cache.f = None
+                cache.df = None
+        
+        def _updatef(seqp,cache):
+            if not cache.f:
+                cache.f = objective(cache.x) if seqp else objective(cache.x[0])
+                if not torch.is_tensor(cache.f) or len(cache.f.size()) > 0:
+                    raise ValueError("Pytorch backend wants a functions that returns a zerodim tensor(scalar)")
+        def cost(x):
+            xx,seqp = _asiterable(x)
+            _updatex(xx,cache)
+            _updatef(seqp,cache)
+            return cache.f.item()
+
+        def _updatedf(seqp,cache):
+            if not cache.df:
+                _updatef(seqp,cache)
+                cache.f.backward(create_graph=True)
+                cache.df = [ xi.grad for xi in cache.x ]
+
+        def egrad(x):
+            xx,seqp = _asiterable(x)
+            _updatex(xx,cache)
+            _updatedf(seqp,cache)
+            return [di.detach().numpy() for di in cache.df] if seqp else cache.df[0].detach().numpy()
+
+        def ehess(x,u):
+            xx,seqp = _asiterable(x)
+            uu,sequ = _asiterable(u)
+            if seqp != sequ or len(xx) != len(uu):
+                raise ValueError("Incompatible lists in ehess")
+            _updatex(xx,cache)
+            _updatedf(seqp,cache)
+            r = 0
+            for (di,ui) in zip(cache.df,uu):
+                n = di.nelement()
+                r = r + torch.dot(di.view(n), _astensor(ui).view(n))
+            h = torch.autograd.grad([r],cache.x,retain_graph=True,allow_unused=True)
+            return [hi.numpy() for hi in h] if seqp else h[0].numpy()
+
+        cache.cost = cost
+        cache.egrad = egrad
+        cache.ehess = ehess
+        return cache
+    
+    @assert_backend_available
+    def compile_function(self, objective, argument):
+        return self._compile(objective, argument).cost
+
+    @assert_backend_available
+    def compute_gradient(self, objective, argument):
+        return self._compile(objective, argument).egrad
+    
+    @assert_backend_available
+    def compute_hessian(self, objective, argument):
+        return self._compile(objective, argument).ehess

--- a/pymanopt/tools/autodiff/_pytorch.py
+++ b/pymanopt/tools/autodiff/_pytorch.py
@@ -38,6 +38,7 @@ class PytorchBackend(Backend):
 
     @assert_backend_available
     def _compile(self, objective, cache):
+        assert isinstance(cache, torch.Tensor) and cache.nelement() == 0
         if hasattr(cache, 'cost'):
             return cache
         cache.x = None    # list woith torch copies of input np.arrays
@@ -88,8 +89,9 @@ class PytorchBackend(Backend):
         def _updatedf(seqp, cache):
             if not cache.df:
                 _updatef(seqp, cache)
-                cache.f.backward(create_graph=True)
-                cache.df = [xi.grad for xi in cache.x]
+                cache.df = torch.autograd.grad(cache.f, cache.x,
+                                               create_graph=True,
+                                               allow_unused=True)
 
         def egrad(x):
             xx, seqp = _asiterable(x)

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -160,12 +160,13 @@ class TestMixed(unittest.TestCase):
         np.seterr(all='raise')
 
         def torchf(x):
-            return (torch.exp(torch.sum(x[0]**2)) + torch.exp(torch.sum(x[1]**2)) +
+            return (torch.exp(torch.sum(x[0]**2)) +
+                    torch.exp(torch.sum(x[1]**2)) +
                     torch.exp(torch.sum(x[2]**2)))
+
         def npf(x):
             return (np.exp(np.sum(x[0]**2)) + np.exp(np.sum(x[1]**2)) +
                     np.exp(np.sum(x[2]**2)))
-        
 
         self.cost = torchf
 
@@ -234,7 +235,7 @@ class TestMixed(unittest.TestCase):
         self.correct_hess = (h1, h2, h3)
         self.backend = PytorchBackend()
         self.arg = torch.Tensor()
-        
+
     def test_compile(self):
         cost_compiled = self.backend.compile_function(self.cost, self.arg)
         np_testing.assert_allclose(self.correct_cost, cost_compiled(self.y))

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -1,0 +1,253 @@
+import unittest
+
+import numpy.random as rnd
+import numpy.testing as np_testing
+import numpy as np
+import torch
+
+from pymanopt.tools.autodiff import PytorchBackend
+
+
+class TestVector(unittest.TestCase):
+    def setUp(self):
+        np.seterr(all='raise')
+
+        self.cost = lambda X: torch.exp(torch.sum(X.pow(2)))
+
+        n = self.n = 15
+
+        Y = self.Y = rnd.randn(n)
+        A = self.A = rnd.randn(n)
+
+        # Calculate correct cost and grad...
+        self.correct_cost = np.exp(np.sum(Y ** 2))
+        self.correct_grad = 2 * Y * np.exp(np.sum(Y ** 2))
+
+        # ... and hess
+        # First form hessian matrix H
+        # Convert Y and A into matrices (row vectors)
+        Ymat = np.matrix(Y)
+        Amat = np.matrix(A)
+
+        diag = np.eye(n)
+
+        H = np.exp(np.sum(Y ** 2)) * (4 * Ymat.T.dot(Ymat) + 2 * diag)
+
+        # Then 'left multiply' H by A
+        self.correct_hess = np.squeeze(np.array(Amat.dot(H)))
+
+        self.backend = PytorchBackend()
+        self.arg = torch.Tensor()
+
+    def test_compile(self):
+        cost_compiled = self.backend.compile_function(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_cost, cost_compiled(self.Y))
+
+    def test_grad(self):
+        grad = self.backend.compute_gradient(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_grad, grad(self.Y))
+
+    def test_hessian(self):
+        hess = self.backend.compute_hessian(self.cost, self.arg)
+
+        # Now test hess
+        np_testing.assert_allclose(self.correct_hess, hess(self.Y, self.A))
+
+
+class TestMatrix(unittest.TestCase):
+    def setUp(self):
+        np.seterr(all='raise')
+
+        self.cost = lambda X: torch.exp(torch.sum(X.pow(2)))
+
+        m = self.m = 10
+        n = self.n = 15
+
+        Y = self.Y = rnd.randn(m, n)
+        A = self.A = rnd.randn(m, n)
+
+        # Calculate correct cost and grad...
+        self.correct_cost = np.exp(np.sum(Y ** 2))
+        self.correct_grad = 2 * Y * np.exp(np.sum(Y ** 2))
+
+        # ... and hess
+        # First form hessian tensor H (4th order)
+        Y1 = Y.reshape(m, n, 1, 1)
+        Y2 = Y.reshape(1, 1, m, n)
+
+        # Create an m x n x m x n array with diag[i,j,k,l] == 1 iff
+        # (i == k and j == l), this is a 'diagonal' tensor.
+        diag = np.eye(m * n).reshape(m, n, m, n)
+
+        H = np.exp(np.sum(Y ** 2)) * (4 * Y1 * Y2 + 2 * diag)
+
+        # Then 'right multiply' H by A
+        Atensor = A.reshape(1, 1, m, n)
+
+        self.correct_hess = np.sum(H * Atensor, axis=(2, 3))
+
+        self.backend = PytorchBackend()
+        self.arg = torch.Tensor()
+
+    def test_compile(self):
+        cost_compiled = self.backend.compile_function(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_cost, cost_compiled(self.Y))
+
+    def test_grad(self):
+        grad = self.backend.compute_gradient(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_grad, grad(self.Y))
+
+    def test_hessian(self):
+        hess = self.backend.compute_hessian(self.cost, self.arg)
+
+        # Now test hess
+        np_testing.assert_allclose(self.correct_hess, hess(self.Y, self.A))
+
+
+class TestTensor3(unittest.TestCase):
+    def setUp(self):
+        np.seterr(all='raise')
+
+        self.cost = lambda X: torch.exp(torch.sum(X.pow(2)))
+
+        n1 = self.n1 = 3
+        n2 = self.n2 = 4
+        n3 = self.n3 = 5
+
+        Y = self.Y = rnd.randn(n1, n2, n3)
+        A = self.A = rnd.randn(n1, n2, n3)
+
+        # Calculate correct cost and grad...
+        self.correct_cost = np.exp(np.sum(Y ** 2))
+        self.correct_grad = 2 * Y * np.exp(np.sum(Y ** 2))
+
+        # ... and hess
+        # First form hessian tensor H (6th order)
+        Y1 = Y.reshape(n1, n2, n3, 1, 1, 1)
+        Y2 = Y.reshape(1, 1, 1, n1, n2, n3)
+
+        # Create an n1 x n2 x n3 x n1 x n2 x n3 diagonal tensor
+        diag = np.eye(n1 * n2 * n3).reshape(n1, n2, n3, n1, n2, n3)
+
+        H = np.exp(np.sum(Y ** 2)) * (4 * Y1 * Y2 + 2 * diag)
+
+        # Then 'right multiply' H by A
+        Atensor = A.reshape(1, 1, 1, n1, n2, n3)
+
+        self.correct_hess = np.sum(H * Atensor, axis=(3, 4, 5))
+
+        self.backend = PytorchBackend()
+        self.arg = torch.Tensor()
+
+    def test_compile(self):
+        cost_compiled = self.backend.compile_function(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_cost, cost_compiled(self.Y))
+
+    def test_grad(self):
+        grad = self.backend.compute_gradient(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_grad, grad(self.Y))
+
+    def test_hessian(self):
+        hess = self.backend.compute_hessian(self.cost, self.arg)
+
+        # Now test hess
+        np_testing.assert_allclose(self.correct_hess, hess(self.Y, self.A))
+
+
+class TestMixed(unittest.TestCase):
+    # Test autograd on a tuple containing vector, matrix and tensor3.
+    def setUp(self):
+        np.seterr(all='raise')
+
+        def torchf(x):
+            return (torch.exp(torch.sum(x[0]**2)) + torch.exp(torch.sum(x[1]**2)) +
+                    torch.exp(torch.sum(x[2]**2)))
+        def npf(x):
+            return (np.exp(np.sum(x[0]**2)) + np.exp(np.sum(x[1]**2)) +
+                    np.exp(np.sum(x[2]**2)))
+        
+
+        self.cost = torchf
+
+        n1 = self.n1 = 3
+        n2 = self.n2 = 4
+        n3 = self.n3 = 5
+        n4 = self.n4 = 6
+        n5 = self.n5 = 7
+        n6 = self.n6 = 8
+
+        self.y = y = (rnd.randn(n1), rnd.randn(n2, n3), rnd.randn(n4, n5, n6))
+        self.a = a = (rnd.randn(n1), rnd.randn(n2, n3), rnd.randn(n4, n5, n6))
+
+        self.correct_cost = npf(y)
+
+        # CALCULATE CORRECT GRAD
+        g1 = 2 * y[0] * np.exp(np.sum(y[0] ** 2))
+        g2 = 2 * y[1] * np.exp(np.sum(y[1] ** 2))
+        g3 = 2 * y[2] * np.exp(np.sum(y[2] ** 2))
+
+        self.correct_grad = (g1, g2, g3)
+
+        # CALCULATE CORRECT HESS
+        # 1. VECTOR
+        Ymat = np.matrix(y[0])
+        Amat = np.matrix(a[0])
+
+        diag = np.eye(n1)
+
+        H = np.exp(np.sum(y[0] ** 2)) * (4 * Ymat.T.dot(Ymat) + 2 * diag)
+
+        # Then 'left multiply' H by A
+        h1 = np.array(Amat.dot(H)).flatten()
+
+        # 2. MATRIX
+        # First form hessian tensor H (4th order)
+        Y1 = y[1].reshape(n2, n3, 1, 1)
+        Y2 = y[1].reshape(1, 1, n2, n3)
+
+        # Create an m x n x m x n array with diag[i,j,k,l] == 1 iff
+        # (i == k and j == l), this is a 'diagonal' tensor.
+        diag = np.eye(n2 * n3).reshape(n2, n3, n2, n3)
+
+        H = np.exp(np.sum(y[1] ** 2)) * (4 * Y1 * Y2 + 2 * diag)
+
+        # Then 'right multiply' H by A
+        Atensor = a[1].reshape(1, 1, n2, n3)
+
+        h2 = np.sum(H * Atensor, axis=(2, 3))
+
+        # 3. Tensor3
+        # First form hessian tensor H (6th order)
+        Y1 = y[2].reshape(n4, n5, n6, 1, 1, 1)
+        Y2 = y[2].reshape(1, 1, 1, n4, n5, n6)
+
+        # Create an n1 x n2 x n3 x n1 x n2 x n3 diagonal tensor
+        diag = np.eye(n4 * n5 * n6).reshape(n4, n5, n6, n4, n5, n6)
+
+        H = np.exp(np.sum(y[2] ** 2)) * (4 * Y1 * Y2 + 2 * diag)
+
+        # Then 'right multiply' H by A
+        Atensor = a[2].reshape(1, 1, 1, n4, n5, n6)
+
+        h3 = np.sum(H * Atensor, axis=(3, 4, 5))
+
+        self.correct_hess = (h1, h2, h3)
+        self.backend = PytorchBackend()
+        self.arg = torch.Tensor()
+        
+    def test_compile(self):
+        cost_compiled = self.backend.compile_function(self.cost, self.arg)
+        np_testing.assert_allclose(self.correct_cost, cost_compiled(self.y))
+
+    def test_grad(self):
+        grad = self.backend.compute_gradient(self.cost, self.arg)
+        for k in range(len(grad(self.y))):
+            np_testing.assert_allclose(self.correct_grad[k], grad(self.y)[k])
+
+    def test_hessian(self):
+        hess = self.backend.compute_hessian(self.cost, self.arg)
+
+        # Now test hess
+        for k in range(len(hess(self.y, self.a))):
+            np_testing.assert_allclose(self.correct_hess[k], hess(self.y,
+                                                                  self.a)[k])


### PR DESCRIPTION
This contains a pytorch backend for pymanopt without changing anything else. The selection of the pytorch backend depends on adding `arg=torch.Tensor()` when creating the `Problem` instance, as illustrated in the [additional examples](https://github.com/leonbottou/pymanopt/blob/master/examples/pca_pytorch.py). 

The pytorch tape based differentiation requires us to compute the cost whenever we want the gradient, and to compute the gradient whenever we want the Hessian. To avoid all these duplicate computations, the additional `arg=torch.Tensor()` serves in fact as a container to cache all the  computations performed for the latest value of `x`.   Other than that, the implement pretty straightforward.

