### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,19 @@ install:
   - pip install coveralls
   - pip install autograd
   - pip install theano
+  # Avoid compiling and failing to compile version of numpy with Python 3.4
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then pip install 'numpy==1.15.4'; fi
   - pip install tensorflow
   - python setup.py install
 
 script:
   - nosetests ./tests --nologcapture --verbosity=2 --with-coverage --cover-package=pymanopt
-  - flake8 examples pymanopt tests setup.py
+  # flake8 fails with Python-2.7 for int comparison, ok with later version
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      flake8 --extend-ignore=F632 examples pymanopt tests setup.py;
+    else
+      flake8 examples pymanopt tests setup.py;
+    fi
 
 after_success:
   - coveralls


### PR DESCRIPTION
While proposing a code update in PR #70, I ran into two issues with Travis:
- in Python 2.7, the `flake8` return a blocking warning for int comparison. This  could be discarded with `--extend-ignore=F632` option.
- Travis fails to install required dependencies in Python 3.4 (does not occur in 3.5 and 3.6). In practice, `pip install` during Travis setup tries to find a Numpy version compatible with Tensorflow and resolves the constraints by trying to locally compile Numpy, which fail on Travis. It is possible to avoid this problem by indicating a specific Numpy version compatible with Tensorflow and with binary install available on pip servers. 