### PR TITLE
manifold.py: don't use ABCMeta as metaclass

### DIFF
--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -65,7 +65,11 @@ class Manifold(object):
         to the manifold at X. For embedded manifolds, this is simply the
         projection of G on the tangent space at X.
         """
-        raise NotImplementedError
+        # TODO(nkoep): Raise a NotImplementedError here instead. Then add a
+        #              base class for submanifolds embedded in Rn for which the
+        #              conversion of the Euclidean to the Riemannian gradient
+        #              is just a projection on the tangent space.
+        return self.proj(X, G)
 
     def ehess2rhess(self, X, Hess):
         """

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -1,8 +1,3 @@
-import abc
-
-import numpy as np
-
-
 class Manifold(object):
     """
     Abstract base class setting out a template for manifold classes. If you
@@ -24,45 +19,45 @@ class Manifold(object):
     methods in this class have equivalents in Manopt with the same name).
     """
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
     def __str__(self):
         """
         Name of the manifold
         """
+        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
     def dim(self):
         """
         Dimension of the manifold
         """
+        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
     def typicaldist(self):
         """
         Returns the "scale" of the manifold. This is used by the
         trust-regions solver, to determine default initial and maximal
         trust-region radii.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def dist(self, X, Y):
         """
         Geodesic distance on the manifold
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def inner(self, X, G, H):
         """
         Inner product (Riemannian metric) on the tangent space
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def proj(self, X, G):
         """
         Project into the tangent space. Usually the same as egrad2rgrad
         """
+        raise NotImplementedError
 
     def egrad2rgrad(self, X, G):
         """
@@ -70,70 +65,70 @@ class Manifold(object):
         to the manifold at X. For embedded manifolds, this is simply the
         projection of G on the tangent space at X.
         """
-        return self.proj(X, G)
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def ehess2rhess(self, X, Hess):
         """
         Convert Euclidean into Riemannian Hessian.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def retr(self, X, G):
         """
         A retraction mapping from the tangent space at X to the manifold.
         See Absil for definition of retraction.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def norm(self, X, G):
         """
         Compute the norm of a tangent vector G, which is tangent to the
         manifold at X.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def rand(self):
         """
         A function which returns a random point on the manifold.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def randvec(self, X):
         """
         Returns a random, unit norm vector in the tangent space at X.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def transp(self, x1, x2, d):
         """
         Transports d, which is a tangent vector at x1, into the tangent
         space at x2.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def exp(self, X, U):
         """
         The exponential (in the sense of Lie group theory) of a tangent
         vector U at X.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def log(self, X, Y):
         """
         The logarithm (in the sense of Lie group theory) of Y. This is the
         inverse of exp.
         """
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def pairmean(self, X, Y):
         """
         Computes the intrinsic mean of X and Y, that is, a point that lies
         mid-way between X and Y on the geodesic arc joining them.
         """
+        raise NotImplementedError
 
     def zerovec(self, X):
         """
         Returns the zero tangent vector at X.
         """
-        return np.zeros(np.shape(X))
+        raise NotImplementedError


### PR DESCRIPTION
Not every solver requires all manifold methods specified in the base class. Instead of requiring that all methods are implemented by subclasses (which wasn't properly enforced by the current implementation either), it seems cleaner to raise `NotImplementedError` exceptions to hint to users that a method is required for a particular solver to be used.