### PR TITLE
travis.yml: fix build after pip 20 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     update: true
 
 install:
-  - pip install --upgrade pip setuptools wheel
+  - pip install --upgrade "pip<20.0" setuptools wheel
   - pip install -q -r dev-requirements.txt
   - pip install -q -r requirements.txt
 


### PR DESCRIPTION
This constrains pip to versions below 20.0 for the moment after the
breakage due to the latest pip release.

cf. https://github.com/pypa/pip/issues/7620

Signed-off-by: Niklas Koep <niklas.koep@gmail.com>