### PR TITLE
Deploy website to master branch of pymanopt.github.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
     github_token: $GITHUB_PAGES_TOKEN
     keep_history: true
     repo: pymanopt/pymanopt.github.io
-    target_branch: deploy
+    target_branch: master
     fqdn: www.pymanopt.org
     project_name: pymanopt
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,21 +27,21 @@ install:
 script:
   - >
     nosetests tests
-      --nologcapture
-      --verbosity=2
-      --with-coverage
-      --cover-package=pymanopt
-    - flake8 examples pymanopt tests setup.py
+    --nologcapture
+    --verbosity=2
+    --with-coverage
+    --cover-package=pymanopt
+  - flake8 examples pymanopt tests setup.py
 
 after_success:
   - coveralls
   - >
     PYTHONPATH=. sphinx-build
-      -b html
-      -D version=dev
-      -D release=dev
-      docs
-      website/docs
+    -b html
+    -D version=dev
+    -D release=dev
+    docs
+    website/docs
 
 deploy:
   - provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,15 +27,21 @@ install:
 script:
   - >
     nosetests tests
-    --nologcapture
-    --verbosity=2
-    --with-coverage
-    --cover-package=pymanopt
-  - flake8 examples pymanopt tests setup.py
-  - PYTHONPATH=. sphinx-build -b html docs website/docs
+      --nologcapture
+      --verbosity=2
+      --with-coverage
+      --cover-package=pymanopt
+    - flake8 examples pymanopt tests setup.py
 
 after_success:
   - coveralls
+  - >
+    PYTHONPATH=. sphinx-build
+      -b html
+      -D version=dev
+      -D release=dev
+      docs
+      website/docs
 
 deploy:
   - provider: pypi
@@ -58,5 +64,4 @@ deploy:
       condition: $TRAVIS_PYTHON_VERSION = "3.7"
       branch: master
       repo: pymanopt/pymanopt
-      # tags: true
     local_dir: website

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,3 +27,4 @@ html_theme = "sphinx_rtd_theme"
 html_show_sphinx = False
 html_baseurl = "www.pymanopt.org"
 htmlhelp_basename = "pymanoptdoc"
+html_last_updated_fmt = ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 autograd
-numpy
+numpy>=1.16
 scipy
 tensorflow==1.15
 theano

--- a/website/README.md
+++ b/website/README.md
@@ -1,4 +1,5 @@
 # pymanopt.org
 
 This repository contains the auto-generated website and documentation of
-*pymanopt*. Refer to the pymanopt/pymanopt repository for the source code.
+**pymanopt**. Refer to github.com/pymanopt/pymanopt for the source code
+generating the contents of this repository.

--- a/website/README.md
+++ b/website/README.md
@@ -1,0 +1,4 @@
+# pymanopt.org
+
+This repository contains the auto-generated website and documentation of
+*pymanopt*. Refer to the pymanopt/pymanopt repository for the source code.


### PR DESCRIPTION
For now, we build/deploy the website on every commit to the master branch, so we always host the most recent docs reflecting the current HEAD. In the future, we should also think about hosting documentation for the stable (pypi) version in parallel to the dev version.