### PR TITLE
Purge py2k remnants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,9 @@
 # Pymanopt TODO List
 
-- Integrate `flake8-import-order` into travis config
+- Development
+  - Integrate `flake8-import-order` into travis config
+  - Integrate flake8-docstrings (add 'docstring-convention = numpy' in [flake8]
+    section of .flake8 file)
 
 - Build and deploy dev documentation for non-tag merges to master
 
@@ -18,3 +21,11 @@
   - autodiff autograd: move type checking outside of compiled function
   - autodiff/_theano [@82](./pymanopt/tools/autodiff/_theano.py#L82): fix theano's no Rop fallback for the product manifold/investigate whether this no Rop fallback is really necessary
   - autodiff/_autograd: fix product manifold when one or more of the manifolds is FixedRankEmbedded
+
+- Misc:
+  - remove all xrange refs
+  - never inherit from object
+  - get rid of py2k super(Bla, self).__meth__() calls
+  - always use "".format rather than "%s" % "bla"
+  - set up pre-commit hook to run flake8 tests (also add this to contrib.md)
+  - drop python 3.5 support so we can switch to f-strings

--- a/TODO.md
+++ b/TODO.md
@@ -23,8 +23,6 @@
   - autodiff/_autograd: fix product manifold when one or more of the manifolds is FixedRankEmbedded
 
 - Misc:
-  - remove all xrange refs
-  - never inherit from object
   - get rid of py2k super(Bla, self).__meth__() calls
   - always use "".format rather than "%s" % "bla"
   - set up pre-commit hook to run flake8 tests (also add this to contrib.md)

--- a/examples/rank_k_correlation_matrix_approximation.py
+++ b/examples/rank_k_correlation_matrix_approximation.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import numpy as np
 import numpy.random as rnd
 import numpy.linalg as la

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -7,7 +7,7 @@ from pymanopt.tools.autodiff import (AutogradBackend, TheanoBackend,
                                      TensorflowBackend)
 
 
-class Problem(object):
+class Problem:
     """
     Problem class for setting up a problem to feed to one of the
     pymanopt solvers.

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -2,7 +2,6 @@
 Module containing pymanopt problem class. Use this to build a problem
 object to feed to one of the solvers.
 """
-from __future__ import print_function
 
 from pymanopt.tools.autodiff import (AutogradBackend, TheanoBackend,
                                      TensorflowBackend)

--- a/pymanopt/manifolds/complexcircle.py
+++ b/pymanopt/manifolds/complexcircle.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd

--- a/pymanopt/manifolds/euclidean.py
+++ b/pymanopt/manifolds/euclidean.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd

--- a/pymanopt/manifolds/fixed_rank.py
+++ b/pymanopt/manifolds/fixed_rank.py
@@ -2,8 +2,6 @@
 Module containing manifolds of fixed rank matrices.
 """
 
-from __future__ import division
-
 import numpy as np
 
 from pymanopt.manifolds.manifold import Manifold

--- a/pymanopt/manifolds/grassmann.py
+++ b/pymanopt/manifolds/grassmann.py
@@ -4,9 +4,6 @@ from numpy.linalg import svd
 from pymanopt.tools.multi import multiprod, multitransp
 from pymanopt.manifolds.manifold import Manifold
 
-if not hasattr(__builtins__, "xrange"):
-    xrange = range
-
 
 class Grassmann(Manifold):
     """
@@ -111,7 +108,7 @@ class Grassmann(Manifold):
             return q
 
         X = np.zeros((self._k, self._n, self._p))
-        for i in xrange(self._k):
+        for i in range(self._k):
             X[i], r = np.linalg.qr(np.random.randn(self._n, self._p))
         return X
 

--- a/pymanopt/manifolds/grassmann.py
+++ b/pymanopt/manifolds/grassmann.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 from numpy.linalg import svd
 

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -3,7 +3,7 @@ import abc
 import numpy as np
 
 
-class Manifold(object):
+class Manifold:
     """
     Abstract base class setting out a template for manifold classes. If you
     would like to extend Pymanopt with a new manifold, then your manifold

--- a/pymanopt/manifolds/oblique.py
+++ b/pymanopt/manifolds/oblique.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd

--- a/pymanopt/manifolds/product.py
+++ b/pymanopt/manifolds/product.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 
 from pymanopt.manifolds.manifold import Manifold

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import warnings
 
 import numpy as np

--- a/pymanopt/manifolds/rotations.py
+++ b/pymanopt/manifolds/rotations.py
@@ -2,8 +2,6 @@
 Module containing manifolds of n-dimensional rotations
 """
 
-from __future__ import division
-
 import numpy as np
 import numpy.linalg as la
 import numpy.random as rnd

--- a/pymanopt/manifolds/sphere.py
+++ b/pymanopt/manifolds/sphere.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import warnings
 
 import numpy as np

--- a/pymanopt/manifolds/stiefel.py
+++ b/pymanopt/manifolds/stiefel.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 from scipy.linalg import expm
 

--- a/pymanopt/manifolds/stiefel.py
+++ b/pymanopt/manifolds/stiefel.py
@@ -4,9 +4,6 @@ from scipy.linalg import expm
 from pymanopt.tools.multi import multiprod, multitransp, multisym
 from pymanopt.manifolds.manifold import Manifold
 
-if not hasattr(__builtins__, "xrange"):
-    xrange = range
-
 
 class Stiefel(Manifold):
     """
@@ -77,7 +74,7 @@ class Stiefel(Manifold):
             XNew = np.dot(q, np.diag(np.sign(np.sign(np.diag(r))+.5)))
         else:
             XNew = X + G
-            for i in xrange(self._k):
+            for i in range(self._k):
                 q, r = np.linalg.qr(XNew[i])
                 XNew[i] = np.dot(q, np.diag(np.sign(np.sign(np.diag(r))+.5)))
         return XNew
@@ -96,7 +93,7 @@ class Stiefel(Manifold):
             return q
 
         X = np.zeros((self._k, self._n, self._p))
-        for i in xrange(self._k):
+        for i in range(self._k):
             X[i], r = np.linalg.qr(np.random.randn(self._n, self._p))
         return X
 
@@ -121,7 +118,7 @@ class Stiefel(Manifold):
             Y = np.bmat([X, U]).dot(W).dot(Z)
         else:
             Y = np.zeros(np.shape(X))
-            for i in xrange(self._k):
+            for i in range(self._k):
                 W = expm(np.bmat([[X[i].T.dot(U[i]), -U[i].T.dot(U[i])],
                                   [np.eye(self._p), X[i].T.dot(U[i])]]))
                 Z = np.bmat([[expm(-X[i].T.dot(U[i]))],

--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import time
 from copy import deepcopy
 

--- a/pymanopt/solvers/linesearch.py
+++ b/pymanopt/solvers/linesearch.py
@@ -1,4 +1,4 @@
-class LineSearchBackTracking(object):
+class LineSearchBackTracking:
     """
     Back-tracking line-search based on linesearch.m in the manopt MATLAB
     package.
@@ -76,7 +76,7 @@ class LineSearchBackTracking(object):
         return stepsize, newx
 
 
-class LineSearchAdaptive(object):
+class LineSearchAdaptive:
     '''
     Adaptive line-search
     '''

--- a/pymanopt/solvers/linesearch.py
+++ b/pymanopt/solvers/linesearch.py
@@ -1,6 +1,3 @@
-from __future__ import division
-
-
 class LineSearchBackTracking(object):
     """
     Back-tracking line-search based on linesearch.m in the manopt MATLAB

--- a/pymanopt/solvers/nelder_mead.py
+++ b/pymanopt/solvers/nelder_mead.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import time
 
 import numpy as np

--- a/pymanopt/solvers/particle_swarm.py
+++ b/pymanopt/solvers/particle_swarm.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import time
 
 import numpy as np

--- a/pymanopt/solvers/solver.py
+++ b/pymanopt/solvers/solver.py
@@ -2,7 +2,7 @@ import time
 import abc
 
 
-class Solver(object):
+class Solver:
     '''
     Abstract base class setting out template for solver classes.
     '''

--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import time
 from copy import deepcopy
 

--- a/pymanopt/solvers/trust_regions.py
+++ b/pymanopt/solvers/trust_regions.py
@@ -57,9 +57,6 @@ import numpy as np
 
 from pymanopt.solvers.solver import Solver
 
-if not hasattr(__builtins__, "xrange"):
-    xrange = range
-
 
 class TrustRegions(Solver):
     (NEGATIVE_CURVATURE, EXCEEDED_TR, REACHED_TARGET_LINEAR,
@@ -439,7 +436,7 @@ class TrustRegions(Solver):
         stop_tCG = self.MAX_INNER_ITER
 
         # Begin inner/tCG loop.
-        for j in xrange(0, int(maxinner)):
+        for j in range(int(maxinner)):
             # This call is the computationally intensive step
             Hdelta = hess(x, delta)
 

--- a/pymanopt/solvers/trust_regions.py
+++ b/pymanopt/solvers/trust_regions.py
@@ -51,8 +51,6 @@
 
 # Ported to pymanopt by Jamie Townsend. January 2016.
 
-from __future__ import print_function, division
-
 import time
 
 import numpy as np

--- a/pymanopt/tools/autodiff/_backend.py
+++ b/pymanopt/tools/autodiff/_backend.py
@@ -11,7 +11,7 @@ def assert_backend_available(f):
     return inner
 
 
-class Backend(object):
+class Backend:
     def __str__(self):
         return "<backend>"
 

--- a/tests/test_manifold_fixed_rank.py
+++ b/tests/test_manifold_fixed_rank.py
@@ -80,7 +80,7 @@ class TestFixedRankEmbeddedManifold(unittest.TestCase):
         u = e.randvec(x)
         A = e.proj(x, e.tangent2ambient(x, u))
         B = u
-        # diff = [A[k]-B[k] for k in xrange(len(A))]
+        # diff = [A[k]-B[k] for k in range(len(A))]
         np_testing.assert_allclose(A[0], B[0])
         np_testing.assert_allclose(A[1], B[1])
         np_testing.assert_allclose(A[2], B[2])


### PR DESCRIPTION
This PR removes (most) any python 2 specific artifacts such as `xrange` and inheritance from `object`. It leaves `super()` calls alone for the moment as this'll get (mostly) cleaned up by https://github.com/pymanopt/pymanopt/pull/94.