### PR TITLE
Add optional developer tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: check-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: flake8
+      - id: mixed-line-ending
+        args:
+          - --fix=no
+      - id: no-commit-to-branch
+      - id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,4 +11,6 @@ repos:
         args:
           - --fix=no
       - id: no-commit-to-branch
+        args:
+          - --branch=master
       - id: trailing-whitespace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,13 @@
 
     git clone git@github.com:your-username/pymanopt.git
 
+Set up a local development environment, installing both the runtime and
+development dependencies listed in the `dev-requirements.txt` and
+`requirements.txt` files. We provide a simple bootstrapping script in
+`tools/bootstrap-pyenv-virtualenv.sh` to set up a local development
+environment. The script requires `pyenv` and `pyenv-virtualenv` to be installed
+and configured.
+
 Verify that all existing tests pass by either running
 
     python setup.py test
@@ -12,9 +19,14 @@ or executing the test suite via [nose][nose]:
 
     nosetests
 
-Note that we also run the [flake8][flake8] utility on every python file in the
-package to verify coding style consistency. As such, failure to comply to the
-[style guide][style] will result in a failing travis-ci build.
+Note that we run the [flake8][flake8] utility on every python file in the
+package to verify coding style consistency during our integration tests. As
+such, failure to comply to the [style guide][style] will result in a failing
+travis-ci build. To prevent adding commits which fail to adhere to the PEP8
+guidelines, we include a [pre-commit][pre-commit] config, which immediately
+invokes flake8 on all files staged for commit when running `git commit`. To
+enable the hook, simply run `pre-commit install` after installing `pre-commit`
+either manually via `pip` as part of `dev-requirements.txt`.
 
 Push a feature branch to your fork and [submit a pull request][pr]. Refer to
 [this guide][commits] on how to write good commit messages.
@@ -26,9 +38,16 @@ project you certify that
 
 * you have the right to submit it to Pymanopt.
 
-* you created the contribution/modification; or you based it on previous work that, to the best of your knowledge, is covered by a compatible open source license; or someone who did one of the former provided you with this contribution/modification and you are submitting it without changes.
+* you created the contribution/modification; or you based it on previous work
+  that, to the best of your knowledge, is covered by a compatible open source
+  license; or someone who did one of the former provided you with this
+  contribution/modification and you are submitting it without changes.
 
-* you understand and agree that your contribution/modification to this project is public and that a record of it (including all information you submit with it, including copyright notices and your sign-off) is maintained indefinitely and may be redistributed consistent with Pymanopt's 3-clause BSD license or the open source license(s) involved.
+* you understand and agree that your contribution/modification to this project
+  is public and that a record of it (including all information you submit with
+  it, including copyright notices and your sign-off) is maintained indefinitely
+  and may be redistributed consistent with Pymanopt's 3-clause BSD license or
+  the open source license(s) involved.
 
 To make your certification explicit we borrow the "sign-off" procedure
 from the Linux kernel project, i.e., each commit message should contain
@@ -42,6 +61,7 @@ with the -s option automatically adds this line.
 [fork]: https://help.github.com/articles/cloning-a-repository/
 [nose]: https://nose.readthedocs.org/en/latest/
 [flake8]: http://flake8.pycqa.org/en/latest/
+[pre-commit]: https://pre-commit.com/
 [style]: https://www.python.org/dev/peps/pep-0008/
 [pr]: https://github.com/j-towns/pymanopt/compare
 [commits]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 coveralls
 flake8
 nose
+pre-commit
 sphinx
 sphinx_rtd_theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 coveralls
 flake8
+nose
 sphinx
 sphinx_rtd_theme

--- a/tools/bootstrap-pyenv-virtualenv.sh
+++ b/tools/bootstrap-pyenv-virtualenv.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -o errexit
+
+# With `pyenv` and its `pyenv-virtualenv` plugin installed, this script
+# bootstraps a Python 3.7 development environment.
+
+die() {
+  echo $*
+  exit 1
+}
+
+for p in pyenv; do
+  command -v $p >/dev/null 2>&1 || { die "\`$p\` not found in PATH"; }
+done
+
+CONFIGURE_OPTS=--enable-shared pyenv install 3.7.6
+pyenv virtualenv 3.7.6 pymanopt-3.7
+pip install --upgrade pip setuptools wheel
+pip install -r dev-requirements.txt
+pip install -r requirements.txt


### PR DESCRIPTION
This PR adds support for some useful development workflow tools. Most importantly, it adds a `pre-commit` config which, when enabled/installed, runs certain pre-commit hooks to enforce coding style. Right now, it also includes an option which disallows direct commits to master to ensure that we always use topic branches. If this is too restrictive, we may remove it again in the future.