### PR TITLE
Fix potential bug in 'SteepestDescent' solver

### DIFF
--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -11,7 +11,7 @@ class SteepestDescent(Solver):
     steepestdescent.m from the manopt MATLAB package.
     """
 
-    def __init__(self, linesearch=LineSearchBackTracking(), *args, **kwargs):
+    def __init__(self, linesearch=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         if linesearch is None:


### PR DESCRIPTION
The 'SteepestDescent' solver was previously initialized with a default
line searcher instance instantiated at class definition time by means of
a default kwarg in its constructor. This means that the same default
value got shared across multiple instances of the 'SteepestDescent'
solver. Since the line searcher is stateful, this may lead to unintended
side-effects when the default line searcher isn't re-initialized inside
the solver's constructor.

Signed-off-by: Niklas Koep <niklas.koep@gmail.com>