### PR TITLE
[FIX] Setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ if __name__ == "__main__":
             "CONTRIBUTORS",
             "LICENSE",
             "MAINTAINERS",
-            "README.md",
-            "VERSION"
+            "README.md"
         ]
     )


### PR DESCRIPTION
## Description
`pymanopt` fails to install with error `can't copy 'VERSION': doesn't exist or not a regular file`, due to missing VERSION file (following 4efa219d3dee055409ae6367d6d8b35752912de0). In order to fix that, "VERSION" is removed from setup data files in setup.py.

