### PR TITLE
Obtain function signature information from manifolds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ target/
 # Miscellaneous
 manopt-*
 
-examples/.ipynb_checkpoints
+*.ipynb_checkpoints
 
 # pyenv
 .python-version

--- a/examples/dominant_invariant_subspace.py
+++ b/examples/dominant_invariant_subspace.py
@@ -37,14 +37,7 @@ def create_cost_egrad_ehess(backend, A, p):
         def egrad(X):
             return -(A + A.T) @ X
 
-        # FIXME(nkoep): With the 'Callable' decorator, the backend currently
-        #               interprets the 'ehess' function as a regular nary
-        #               function, which should be wrapped in a unary function
-        #               whose arguments get unpacked when the function is
-        #               called. We need a way to signal to the backend that
-        #               'ehess' implements a Hessian-vector product, which
-        #               requires two arguments.
-        # @pymanopt.function.Callable
+        @pymanopt.function.Callable
         def ehess(X, H):
             return -(A + A.T) @ H
     elif backend == "PyTorch":

--- a/examples/dominant_invariant_subspace.py
+++ b/examples/dominant_invariant_subspace.py
@@ -61,10 +61,18 @@ def create_cost_egrad_ehess(backend, A, p):
             return -tf.tensordot(X, tf.matmul(A, X), axes=2)
     elif backend == "Theano":
         X = T.matrix()
+        U = T.matrix()
 
         @pymanopt.function.Theano(X)
         def cost(X):
             return -T.dot(X.T, T.dot(A, X)).trace()
+
+        # Define the Euclidean Hessian-vector product explicitly for the
+        # purpose of demonstration. The Euclidean gradient is automatically
+        # calculated via Theano's autodiff capabilities.
+        @pymanopt.function.Theano(X, U)
+        def ehess(X, U):
+            return -T.dot(A + A.T, U)
     else:
         raise ValueError("Unsupported backend '{:s}'".format(backend))
 

--- a/examples/dominant_invariant_subspace.py
+++ b/examples/dominant_invariant_subspace.py
@@ -59,6 +59,13 @@ def create_cost_egrad_ehess(backend, A, p):
         @pymanopt.function.TensorFlow(X)
         def cost(X):
             return -tf.tensordot(X, tf.matmul(A, X), axes=2)
+
+        # Define the Euclidean gradient explicitly for the purpose of
+        # demonstration. The Euclidean Hessian-vector product is automatically
+        # calculated via TensorFlow's autodiff capabilities.
+        @pymanopt.function.TensorFlow(X)
+        def egrad(X):
+            return -tf.matmul(A + A.T, X)
     elif backend == "Theano":
         X = T.matrix()
         U = T.matrix()

--- a/examples/low_rank_psd_matrix_approximation.py
+++ b/examples/low_rank_psd_matrix_approximation.py
@@ -37,7 +37,7 @@ def create_cost_egrad_ehess(backend, A, rank):
         def egrad(Y):
             return 4 * (Y @ Y.T - A) @ Y
 
-        # FIXME(nkoep): See examples/dominant_invariant_subspace.py.
+        @pymanopt.function.Callable
         def ehess(Y, U):
             return 4 * ((Y @ U.T + U @ Y.T) @ Y + (Y @ Y.T - A) @ U)
     elif backend == "PyTorch":

--- a/examples/multiple_linear_regression.py
+++ b/examples/multiple_linear_regression.py
@@ -38,7 +38,7 @@ def create_cost_egrad_ehess(backend, samples, targets):
         def egrad(weights):
             return -2 * samples.T @ (targets - samples @ weights)
 
-        # FIXME(nkoep): See examples/dominant_invariant_subspace.py.
+        @pymanopt.function.Callable
         def ehess(weights, vector):
             return 2 * samples.T @ samples @ vector
     elif backend == "PyTorch":

--- a/examples/notebooks/mixture_of_gaussians.ipynb
+++ b/examples/notebooks/mixture_of_gaussians.ipynb
@@ -108,9 +108,12 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(0,\"..\")\n",
+    "sys.path.insert(0,\"../..\")\n",
+    "\n",
     "import autograd.numpy as np\n",
     "from autograd.scipy.special import logsumexp\n",
+    "\n",
+    "import pymanopt\n",
     "from pymanopt.manifolds import Product, Euclidean, SymmetricPositiveDefinite\n",
     "from pymanopt import Problem\n",
     "from pymanopt.solvers import SteepestDescent\n",
@@ -120,11 +123,11 @@
     "\n",
     "# (2) Define cost function\n",
     "# The parameters must be contained in a list theta.\n",
-    "def cost(theta):\n",
+    "@pymanopt.function.Autograd\n",
+    "def cost(S, v):\n",
     "    # Unpack parameters\n",
-    "    nu = np.concatenate([theta[1], [0]], axis=0)\n",
+    "    nu = np.append(v, 0)\n",
     "    \n",
-    "    S = theta[0]\n",
     "    logdetS = np.expand_dims(np.linalg.slogdet(S)[1], 1)\n",
     "    y = np.concatenate([samples.T, np.ones((1, N))], axis=0)\n",
     "\n",
@@ -331,6 +334,13 @@
     "            return x, objective(x), True\n",
     "        return newx, newf, False"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -349,7 +359,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/pca.py
+++ b/examples/pca.py
@@ -39,8 +39,7 @@ def create_cost_egrad_ehess(backend, samples, num_components):
                 (samples - samples @ w @ w.T).T @ samples
             ) @ w
 
-        # FIXME(nkoep): See examples/dominant_invariant_subspace.py.
-        # @pymanopt.function.Callable
+        @pymanopt.function.Callable
         def ehess(w, h):
             return -2 * (
                 samples.T @ (samples - samples @ w @ h.T) @ w +

--- a/examples/rank_k_correlation_matrix_approximation.py
+++ b/examples/rank_k_correlation_matrix_approximation.py
@@ -37,8 +37,7 @@ def create_cost_egrad_ehess(backend, matrix, rank):
         def egrad(X):
             return 0.5 * X @ (X.T @ X - matrix)
 
-        # FIXME(nkoep): See examples/dominant_invariant_subspace.py.
-        # @pymanopt.function.Callable
+        @pymanopt.function.Callable
         def ehess(X, H):
             return X @ (H.T @ X + X.T @ H) + H @ (X.T @ X - matrix)
     elif backend == "PyTorch":

--- a/pymanopt/autodiff/__init__.py
+++ b/pymanopt/autodiff/__init__.py
@@ -38,15 +38,15 @@ class Function:
     def compute_gradient(self):
         assert self._backend is not None
         if self._egrad is None:
-            self._egrad = self._backend.compute_gradient(self._function,
-                                                         self._args)
+            self._egrad = self._backend.compute_gradient(
+                self._function, self._args)
         return self._egrad
 
-    def compute_hessian(self):
+    def compute_hessian_vector_product(self):
         assert self._backend is not None
         if self._ehess is None:
-            self._ehess = self._backend.compute_hessian(self._function,
-                                                        self._args)
+            self._ehess = self._backend.compute_hessian_vector_product(
+                self._function, self._args)
         return self._ehess
 
     def __call__(self, *args, **kwargs):

--- a/pymanopt/autodiff/__init__.py
+++ b/pymanopt/autodiff/__init__.py
@@ -1,7 +1,5 @@
 import inspect
 
-from ..tools import flatten_arguments
-
 
 class Function:
     def __str__(self):
@@ -63,8 +61,8 @@ def make_tracing_backend_decorator(Backend):
 
     or
 
-      @decorator(("x", "y", "z"), "w")
-      def f(x, y, z, w):
+      @decorator(backend_specific_kwarg=...)
+      def f(x):
           pass
 
     to annotate a tracing-based autodiff function with how the arguments are
@@ -81,6 +79,9 @@ def make_tracing_backend_decorator(Backend):
             return Function(function, args=tuple(argspec.args),
                             backend=Backend())
 
+        if len(args) != 0:
+            raise ValueError("Only keyword arguments allowed")
+
         def inner(function):
             return Function(function, args=args, backend=Backend(**kwargs))
         return inner
@@ -90,7 +91,7 @@ def make_tracing_backend_decorator(Backend):
 def make_graph_backend_decorator(Backend):
     def decorator(*args, **kwargs):
         def inner(function):
-            graph = function(*flatten_arguments(args))
+            graph = function(*args)
             return Function(graph, args=args, backend=Backend(**kwargs))
         return inner
     return decorator

--- a/pymanopt/autodiff/backends/_autograd.py
+++ b/pymanopt/autodiff/backends/_autograd.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ._backend import Backend
 from .. import make_tracing_backend_decorator
-from ...tools import bisect_iterable, unpack_singleton_iterable_return_value
+from ...tools import bisect_sequence, unpack_singleton_iterable_return_value
 
 
 class _AutogradBackend(Backend):
@@ -46,7 +46,7 @@ class _AutogradBackend(Backend):
 
         @functools.wraps(hessian_vector_product)
         def wrapper(*args):
-            arguments, vectors = bisect_iterable(args)
+            arguments, vectors = bisect_sequence(args)
             return hessian_vector_product(*arguments, vectors)
         if num_arguments == 1:
             return unpack_singleton_iterable_return_value(wrapper)

--- a/pymanopt/autodiff/backends/_autograd.py
+++ b/pymanopt/autodiff/backends/_autograd.py
@@ -5,6 +5,7 @@ import functools
 
 try:
     import autograd
+    import autograd.numpy as np
 except ImportError:
     autograd = None
 
@@ -38,10 +39,22 @@ class _AutogradBackend(Backend):
             return unpack_singleton_sequence_return_value(gradient)
         return gradient
 
+    @staticmethod
+    def _hessian_vector_product(function, argnum):
+        gradient = autograd.grad(function, argnum)
+
+        def vector_dot_gradient(*args):
+            arguments, vectors = args[:-1], args[-1]
+            gradients = gradient(*arguments)
+            return np.sum(
+                [np.tensordot(gradient, vector, axes=vector.ndim)
+                 for gradient, vector in zip(gradients, vectors)])
+        return autograd.grad(vector_dot_gradient, argnum)
+
     @Backend._assert_backend_available
     def compute_hessian_vector_product(self, function, arguments):
         num_arguments = len(arguments)
-        hessian_vector_product = autograd.hessian_vector_product(
+        hessian_vector_product = self._hessian_vector_product(
             function, argnum=tuple(range(num_arguments)))
 
         @functools.wraps(hessian_vector_product)

--- a/pymanopt/autodiff/backends/_autograd.py
+++ b/pymanopt/autodiff/backends/_autograd.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ._backend import Backend
 from .. import make_tracing_backend_decorator
-from ...tools import bisect_sequence, unpack_singleton_iterable_return_value
+from ...tools import bisect_sequence, unpack_singleton_sequence_return_value
 
 
 class _AutogradBackend(Backend):
@@ -35,7 +35,7 @@ class _AutogradBackend(Backend):
         num_arguments = len(arguments)
         gradient = autograd.grad(function, argnum=list(range(num_arguments)))
         if num_arguments == 1:
-            return unpack_singleton_iterable_return_value(gradient)
+            return unpack_singleton_sequence_return_value(gradient)
         return gradient
 
     @Backend._assert_backend_available
@@ -49,7 +49,7 @@ class _AutogradBackend(Backend):
             arguments, vectors = bisect_sequence(args)
             return hessian_vector_product(*arguments, vectors)
         if num_arguments == 1:
-            return unpack_singleton_iterable_return_value(wrapper)
+            return unpack_singleton_sequence_return_value(wrapper)
         return wrapper
 
 

--- a/pymanopt/autodiff/backends/_autograd.py
+++ b/pymanopt/autodiff/backends/_autograd.py
@@ -5,13 +5,11 @@ import functools
 
 try:
     import autograd
-    from autograd import numpy as np
 except ImportError:
     autograd = None
 
 from ._backend import Backend
 from .. import make_tracing_backend_decorator
-from ...tools import flatten_arguments, group_return_values, unpack_arguments
 
 
 class _AutogradBackend(Backend):
@@ -29,72 +27,38 @@ class _AutogradBackend(Backend):
 
     @Backend._assert_backend_available
     def compile_function(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        if len(flattened_arguments) == 1:
-            return function
-        return unpack_arguments(function)
+        return function
+
+    def _unpack_return_value(self, function):
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            return function(*args, **kwargs)[0]
+        return wrapper
 
     @Backend._assert_backend_available
     def compute_gradient(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        if len(flattened_arguments) == 1:
-            return autograd.grad(function)
-        # XXX: This path handles cases where the signature hint looks like
-        #      '@Autograd(("x", "y"))'. This is potentially unnecessary as
-        #      tests also pass if we instead use '@Autograd'. Revisit this
-        #      once we ported more complicated examples to autograd.
-        if len(arguments) == 1:
-            @functools.wraps(function)
-            def unary_function(arguments):
-                return function(*arguments)
-            return autograd.grad(unary_function)
-
-        # Turn `function` into a function accepting a single argument which
-        # gets unpacked when the function is called. This is necessary for
-        # autograd to compute and return the gradient for each input in the
-        # input tuple/list and return it in the same grouping.
-        # In order to unpack arguments correctly, we also need a signature hint
-        # in the form of `arguments`. This is because autograd wraps tuples and
-        # lists in `SequenceBox` types which are not derived from tuple or list
-        # so we cannot detect nested arguments automatically.
-        unary_function = unpack_arguments(function, signature=arguments)
-        return autograd.grad(unary_function)
-
-    @staticmethod
-    def _compute_nary_hessian_vector_product(function):
-        gradient = autograd.grad(function)
-
-        def vector_dot_grad(*args):
-            arguments, vectors = args[:-1], args[-1]
-            gradients = gradient(*arguments)
-            return np.sum(
-                [np.tensordot(gradient, vector, axes=vector.ndim)
-                 for gradient, vector in zip(gradients, vectors)])
-        return autograd.grad(vector_dot_grad)
+        num_arguments = len(arguments)
+        gradient = autograd.grad(function, argnum=list(range(num_arguments)))
+        if num_arguments > 1:
+            return gradient
+        return self._unpack_return_value(gradient)
 
     @Backend._assert_backend_available
-    def compute_hessian(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        if len(flattened_arguments) == 1:
-            return autograd.hessian_tensor_product(function)
-        if len(arguments) == 1:
-            @functools.wraps(function)
-            def unary_function(arguments):
-                return function(*arguments)
-            return autograd.hessian_tensor_product(unary_function)
-
-        @functools.wraps(function)
-        def unary_function(arguments):
-            return function(*arguments)
-        hessian_vector_product = self._compute_nary_hessian_vector_product(
-            unary_function)
+    def compute_hessian_vector_product(self, function, arguments):
+        num_arguments = len(arguments)
+        hessian_vector_product = autograd.hessian_vector_product(
+            function, argnum=tuple(range(num_arguments)))
+        if num_arguments == 1:
+            return self._unpack_return_value(hessian_vector_product)
 
         @functools.wraps(hessian_vector_product)
-        def wrapper(point, vector):
-            return hessian_vector_product(
-                flatten_arguments(point, signature=arguments),
-                flatten_arguments(vector, signature=arguments))
-        return group_return_values(wrapper, arguments)
+        def wrapper(*arguments):
+            num_arguments = len(arguments)
+            assert num_arguments % 2 == 0
+            point = arguments[:num_arguments // 2]
+            vector = arguments[num_arguments // 2:]
+            return hessian_vector_product(*point, vector)
+        return wrapper
 
 
 Autograd = make_tracing_backend_decorator(_AutogradBackend)

--- a/pymanopt/autodiff/backends/_backend.py
+++ b/pymanopt/autodiff/backends/_backend.py
@@ -111,7 +111,7 @@ class Backend(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def compute_hessian(self, function, arguments):
+    def compute_hessian_vector_product(self, function, arguments):
         """Computes the Hessian-vector product of function a function and turns
         it into a Python callable.
 

--- a/pymanopt/autodiff/backends/_callable.py
+++ b/pymanopt/autodiff/backends/_callable.py
@@ -1,6 +1,5 @@
 from ._backend import Backend
 from .. import make_tracing_backend_decorator
-from ...tools import flatten_arguments, unpack_arguments
 
 
 class _CallableBackend(Backend):
@@ -17,17 +16,15 @@ class _CallableBackend(Backend):
 
     @Backend._assert_backend_available
     def compile_function(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        if len(flattened_arguments) == 1:
-            return function
-        return unpack_arguments(function)
+        return function
 
     def _raise_not_implemented_error(self, function, arguments):
         raise NotImplementedError(
             "No autodiff support available for the canonical '{}' "
             "backend".format(self))
 
-    compute_gradient = compute_hessian = _raise_not_implemented_error
+    compute_gradient = _raise_not_implemented_error
+    compute_hessian_vector_product = _raise_not_implemented_error
 
 
 Callable = make_tracing_backend_decorator(_CallableBackend)

--- a/pymanopt/autodiff/backends/_pytorch.py
+++ b/pymanopt/autodiff/backends/_pytorch.py
@@ -14,7 +14,7 @@ else:
 
 from ._backend import Backend
 from .. import make_tracing_backend_decorator
-from ...tools import bisect_iterable, unpack_singleton_iterable_return_value
+from ...tools import bisect_sequence, unpack_singleton_iterable_return_value
 
 
 class _PyTorchBackend(Backend):
@@ -83,7 +83,7 @@ class _PyTorchBackend(Backend):
     @Backend._assert_backend_available
     def compute_hessian_vector_product(self, function, arguments):
         def hessian_vector_product(*args):
-            points, vectors = bisect_iterable(args)
+            points, vectors = bisect_sequence(args)
             xs = []
             for point in points:
                 x = self._from_numpy(point)

--- a/pymanopt/autodiff/backends/_pytorch.py
+++ b/pymanopt/autodiff/backends/_pytorch.py
@@ -14,7 +14,7 @@ else:
 
 from ._backend import Backend
 from .. import make_tracing_backend_decorator
-from ...tools import bisect_sequence, unpack_singleton_iterable_return_value
+from ...tools import bisect_sequence, unpack_singleton_sequence_return_value
 
 
 class _PyTorchBackend(Backend):
@@ -77,7 +77,7 @@ class _PyTorchBackend(Backend):
             function(*torch_arguments).backward()
             return self._sanitize_gradients(torch_arguments)
         if len(arguments) == 1:
-            return unpack_singleton_iterable_return_value(gradient)
+            return unpack_singleton_sequence_return_value(gradient)
         return gradient
 
     @Backend._assert_backend_available
@@ -101,7 +101,7 @@ class _PyTorchBackend(Backend):
             dot_product.backward()
             return self._sanitize_gradients(xs)
         if len(arguments) == 1:
-            return unpack_singleton_iterable_return_value(
+            return unpack_singleton_sequence_return_value(
                 hessian_vector_product)
         return hessian_vector_product
 

--- a/pymanopt/autodiff/backends/_tensorflow.py
+++ b/pymanopt/autodiff/backends/_tensorflow.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ._backend import Backend
 from .. import make_graph_backend_decorator
-from ...tools import bisect_sequence, unpack_singleton_iterable_return_value
+from ...tools import bisect_sequence, unpack_singleton_sequence_return_value
 
 
 class _TensorFlowBackend(Backend):
@@ -65,7 +65,7 @@ class _TensorFlowBackend(Backend):
             }
             return self._session.run(gradients, feed_dict)
         if len(variables) == 1:
-            return unpack_singleton_iterable_return_value(gradient)
+            return unpack_singleton_sequence_return_value(gradient)
         return gradient
 
     @staticmethod
@@ -117,7 +117,7 @@ class _TensorFlowBackend(Backend):
             }
             return self._session.run(hessian, feed_dict)
         if len(variables) == 1:
-            return unpack_singleton_iterable_return_value(
+            return unpack_singleton_sequence_return_value(
                 hessian_vector_product)
         return hessian_vector_product
 

--- a/pymanopt/autodiff/backends/_tensorflow.py
+++ b/pymanopt/autodiff/backends/_tensorflow.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ._backend import Backend
 from .. import make_graph_backend_decorator
-from ...tools import bisect_iterable, unpack_singleton_iterable_return_value
+from ...tools import bisect_sequence, unpack_singleton_iterable_return_value
 
 
 class _TensorFlowBackend(Backend):
@@ -108,7 +108,7 @@ class _TensorFlowBackend(Backend):
         hessian = self._hessian_vector_product(function, variables, zeros)
 
         def hessian_vector_product(*args):
-            arguments, vectors = bisect_iterable(args)
+            arguments, vectors = bisect_sequence(args)
             feed_dict = {
                 variable: argument
                 for variable, argument in zip(

--- a/pymanopt/autodiff/backends/_tensorflow.py
+++ b/pymanopt/autodiff/backends/_tensorflow.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ._backend import Backend
 from .. import make_graph_backend_decorator
-from ...tools import flatten_arguments, group_return_values
+from ...tools import unpack_singleton_iterable_return_value
 
 
 class _TensorFlowBackend(Backend):
@@ -36,29 +36,18 @@ class _TensorFlowBackend(Backend):
     def is_compatible(self, function, arguments):
         if not isinstance(function, tf.Tensor):
             return False
-        flattened_arguments = flatten_arguments(arguments)
         return all([isinstance(argument, tf.Variable)
-                    for argument in flattened_arguments])
+                    for argument in arguments])
 
     @Backend._assert_backend_available
-    def compile_function(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        if len(flattened_arguments) == 1:
-            def unary_function(point):
-                (argument,) = flattened_arguments
-                feed_dict = {argument: point}
-                return self._session.run(function, feed_dict)
-            return unary_function
-
-        def nary_function(arguments):
-            flattened_inputs = flatten_arguments(arguments)
+    def compile_function(self, function, variables):
+        def compiled_function(*args):
             feed_dict = {
-                argument: array
-                for argument, array in zip(flattened_arguments,
-                                           flattened_inputs)
+                variable: argument
+                for variable, argument in zip(variables, args)
             }
             return self._session.run(function, feed_dict)
-        return nary_function
+        return compiled_function
 
     @staticmethod
     def _gradients(function, arguments):
@@ -66,26 +55,18 @@ class _TensorFlowBackend(Backend):
                             unconnected_gradients=tf.UnconnectedGradients.ZERO)
 
     @Backend._assert_backend_available
-    def compute_gradient(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        gradient = self._gradients(function, flattened_arguments)
+    def compute_gradient(self, function, variables):
+        gradients = self._gradients(function, variables)
 
-        if len(flattened_arguments) == 1:
-            (argument,) = flattened_arguments
-
-            def unary_gradient(point):
-                feed_dict = {argument: point}
-                return self._session.run(gradient[0], feed_dict)
-            return unary_gradient
-
-        def nary_gradient(points):
+        def gradient(*args):
             feed_dict = {
-                argument: point
-                for argument, point in zip(flattened_arguments,
-                                           flatten_arguments(points))
+                variable: argument
+                for variable, argument in zip(variables, args)
             }
-            return self._session.run(gradient, feed_dict)
-        return group_return_values(nary_gradient, arguments)
+            return self._session.run(gradients, feed_dict)
+        if len(variables) == 1:
+            return unpack_singleton_iterable_return_value(gradient)
+        return gradient
 
     @staticmethod
     def _hessian_vector_product(function, arguments, vectors):
@@ -122,33 +103,26 @@ class _TensorFlowBackend(Backend):
         return _TensorFlowBackend._gradients(element_wise_products, arguments)
 
     @Backend._assert_backend_available
-    def compute_hessian(self, function, arguments):
-        flattened_arguments = flatten_arguments(arguments)
+    def compute_hessian_vector_product(self, function, variables):
+        zeros = [tf.zeros_like(variable) for variable in variables]
+        hessian = self._hessian_vector_product(function, variables, zeros)
 
-        if len(flattened_arguments) == 1:
-            (argument,) = flattened_arguments
-            zeros = tf.zeros_like(argument)
-            hessian = self._hessian_vector_product(
-                function, [argument], [zeros])
-
-            def unary_hessian(point, vector):
-                feed_dict = {argument: point, zeros: vector}
-                return self._session.run(hessian[0], feed_dict)
-            return unary_hessian
-
-        zeros = [tf.zeros_like(argument) for argument in flattened_arguments]
-        hessian = self._hessian_vector_product(
-            function, flattened_arguments, zeros)
-
-        def nary_hessian(points, vectors):
+        def hessian_vector_product(*args):
+            num_arguments = len(args)
+            assert num_arguments % 2 == 0
+            arguments = args[:num_arguments // 2]
+            vectors = args[num_arguments // 2:]
             feed_dict = {
-                argument: value for argument, value in zip(
-                    itertools.chain(flattened_arguments, zeros),
-                    itertools.chain(flatten_arguments(points),
-                                    flatten_arguments(vectors)))
+                variable: argument
+                for variable, argument in zip(
+                    itertools.chain(variables, zeros),
+                    itertools.chain(arguments, vectors))
             }
             return self._session.run(hessian, feed_dict)
-        return group_return_values(nary_hessian, arguments)
+        if len(variables) == 1:
+            return unpack_singleton_iterable_return_value(
+                hessian_vector_product)
+        return hessian_vector_product
 
 
 TensorFlow = make_graph_backend_decorator(_TensorFlowBackend)

--- a/pymanopt/autodiff/backends/_tensorflow.py
+++ b/pymanopt/autodiff/backends/_tensorflow.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ._backend import Backend
 from .. import make_graph_backend_decorator
-from ...tools import unpack_singleton_iterable_return_value
+from ...tools import bisect_iterable, unpack_singleton_iterable_return_value
 
 
 class _TensorFlowBackend(Backend):
@@ -108,10 +108,7 @@ class _TensorFlowBackend(Backend):
         hessian = self._hessian_vector_product(function, variables, zeros)
 
         def hessian_vector_product(*args):
-            num_arguments = len(args)
-            assert num_arguments % 2 == 0
-            arguments = args[:num_arguments // 2]
-            vectors = args[num_arguments // 2:]
+            arguments, vectors = bisect_iterable(args)
             feed_dict = {
                 variable: argument
                 for variable, argument in zip(

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -135,16 +135,16 @@ class Problem:
         return wrapper
 
     def _wrap_function(self, function):
-        point_format = self.manifold.point_format
-        if isinstance(point_format, (tuple, list)):
+        point_layout = self.manifold.point_layout
+        if isinstance(point_layout, (tuple, list)):
             @functools.wraps(function)
             def wrapper(point):
-                return function(*self._flatten_arguments(point, point_format))
+                return function(*self._flatten_arguments(point, point_layout))
             return wrapper
 
-        assert isinstance(point_format, int)
+        assert isinstance(point_layout, int)
 
-        if point_format == 1:
+        if point_layout == 1:
             @functools.wraps(function)
             def wrapper(point):
                 return function(point)
@@ -156,22 +156,22 @@ class Problem:
 
     def _wrap_gradient(self, gradient):
         wrapped_gradient = self._wrap_function(gradient)
-        point_format = self.manifold.point_format
-        if isinstance(point_format, (list, tuple)):
-            self._group_return_values(wrapped_gradient, point_format)
+        point_layout = self.manifold.point_layout
+        if isinstance(point_layout, (list, tuple)):
+            self._group_return_values(wrapped_gradient, point_layout)
         return wrapped_gradient
 
     def _wrap_hessian_vector_product(self, hessian_vector_product):
-        point_format = self.manifold.point_format
-        if isinstance(point_format, (list, tuple)):
+        point_layout = self.manifold.point_layout
+        if isinstance(point_layout, (list, tuple)):
             @functools.wraps(hessian_vector_product)
             def wrapper(point, vector):
                 return hessian_vector_product(
-                    *self._flatten_arguments(point, point_format),
-                    *self._flattened_arguments(vector, point_format))
-            return self._group_return_values(wrapper, point_format)
+                    *self._flatten_arguments(point, point_layout),
+                    *self._flattened_arguments(vector, point_layout))
+            return self._group_return_values(wrapper, point_layout)
 
-        if point_format == 1:
+        if point_layout == 1:
             @functools.wraps(hessian_vector_product)
             def wrapper(point, vector):
                 return hessian_vector_product(point, vector)

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -2,6 +2,9 @@
 Module containing pymanopt problem class. Use this to build a problem
 object to feed to one of the solvers.
 """
+import functools
+
+import numpy as np
 
 
 class Problem:
@@ -44,7 +47,7 @@ class Problem:
                  hess=None, precon=None, verbosity=2):
         self.manifold = manifold
 
-        self.cost = cost
+        self._cost = cost
 
         self._ehess = ehess
         self._egrad = egrad
@@ -69,10 +72,99 @@ class Problem:
                 raise AttributeError("Cannot override 'manifold' attribute")
         super().__setattr__(key, value)
 
+    def _flatten_arguments(self, arguments, signature):
+        flattened_arguments = []
+        for i, group in enumerate(signature):
+            if isinstance(group, (list, tuple)):
+                flattened_arguments.extend(arguments[i])
+            else:
+                flattened_arguments.append(arguments[i])
+        return flattened_arguments
+
+    def _group_return_values(self, function, signature):
+        """Wraps a function inside another function which groups the return
+        values of ``function`` according to the group sizes delineated by
+        ``signature``.
+        """
+        assert all((isinstance(group, int) for group in signature))
+
+        num_return_values = np.sum(signature)
+
+        @functools.wraps(function)
+        def wrapper(*args, **kwargs):
+            return_values = function(*args, **kwargs)
+            if not isinstance(return_values, (list, tuple)):
+                raise ValueError("Function returned an unexpected value")
+            if len(return_values) != num_return_values:
+                raise ValueError(
+                    "Function returned an unexpected number of arguments")
+            groups = []
+            i = 0
+            for group_size in signature:
+                if group_size == 1:
+                    group = return_values[i]
+                else:
+                    group = return_values[i:i+group_size]
+                groups.append(group)
+                i += group_size
+            return groups
+        return wrapper
+
+    def _wrap_function(self, function):
+        point_format = self.manifold.point_format
+        if isinstance(point_format, (tuple, list)):
+            @functools.wraps(function)
+            def wrapper(point):
+                return function(*self._flatten_arguments(point, point_format))
+            return wrapper
+
+        assert isinstance(point_format, int)
+
+        if point_format == 1:
+            @functools.wraps(function)
+            def wrapper(point):
+                return function(point)
+        else:
+            @functools.wraps(function)
+            def wrapper(point):
+                return function(*point)
+        return wrapper
+
+    def _wrap_gradient(self, gradient):
+        wrapped_gradient = self._wrap_function(gradient)
+        point_format = self.manifold.point_format
+        if isinstance(point_format, (list, tuple)):
+            self._group_return_values(wrapped_gradient, point_format)
+        return wrapped_gradient
+
+    def _wrap_hessian_vector_product(self, hessian_vector_product):
+        point_format = self.manifold.point_format
+        if isinstance(point_format, (list, tuple)):
+            @functools.wraps(hessian_vector_product)
+            def wrapper(point, vector):
+                return hessian_vector_product(
+                    *self._flatten_arguments(point, point_format),
+                    *self._flattened_arguments(vector, point_format))
+            return self._group_return_values(wrapper, point_format)
+
+        if point_format == 1:
+            @functools.wraps(hessian_vector_product)
+            def wrapper(point, vector):
+                return hessian_vector_product(point, vector)
+        else:
+            @functools.wraps(hessian_vector_product)
+            def wrapper(point, vector):
+                return hessian_vector_product(*point, *vector)
+        return wrapper
+
+    @property
+    def cost(self):
+        return self._wrap_function(self._cost)
+
     @property
     def egrad(self):
         if self._egrad is None:
-            self._egrad = self.cost.compute_gradient()
+            self._egrad = self._wrap_gradient(self._cost.compute_gradient())
         return self._egrad
 
     @property
@@ -88,7 +180,8 @@ class Problem:
     @property
     def ehess(self):
         if self._ehess is None:
-            self._ehess = self.cost.compute_hessian()
+            self._ehess = self._wrap_hessian_vector_product(
+                self._cost.compute_hessian_vector_product())
         return self._ehess
 
     @property

--- a/pymanopt/manifolds/fixed_rank.py
+++ b/pymanopt/manifolds/fixed_rank.py
@@ -94,7 +94,7 @@ class FixedRankEmbedded(EuclideanEmbeddedSubmanifold):
         name = ("Manifold of {m}-by-{n} matrices with rank {k} and embedded "
                 "geometry".format(m=m, n=n, k=k))
         dimension = (m + n - k) * k
-        super().__init__(name, dimension, point_format=3)
+        super().__init__(name, dimension, point_layout=3)
 
     @property
     def typicaldist(self):

--- a/pymanopt/manifolds/fixed_rank.py
+++ b/pymanopt/manifolds/fixed_rank.py
@@ -94,7 +94,7 @@ class FixedRankEmbedded(EuclideanEmbeddedSubmanifold):
         name = ("Manifold of {m}-by-{n} matrices with rank {k} and embedded "
                 "geometry".format(m=m, n=n, k=k))
         dimension = (m + n - k) * k
-        super().__init__(name, dimension)
+        super().__init__(name, dimension, point_format=3)
 
     @property
     def typicaldist(self):

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -25,11 +25,14 @@ class Manifold(metaclass=abc.ABCMeta):
     methods in this class have equivalents in Manopt with the same name).
     """
 
-    def __init__(self, name, dimension):
+    def __init__(self, name, dimension, point_format=1):
         assert isinstance(dimension, (int, np.integer)), \
-                "dimension must be an integer"
+            "dimension must be an integer"
+        assert isinstance(point_format, int) and point_format > 0, \
+            "point_format must be a positive integer"
         self._name = name
         self._dimension = dimension
+        self._point_format = point_format
 
     def __str__(self):
         """Returns a string representation of the particular manifold."""
@@ -42,6 +45,17 @@ class Manifold(metaclass=abc.ABCMeta):
     def dim(self):
         """The dimension of the manifold"""
         return self._dimension
+
+    @property
+    def point_format(self):
+        """The number of elements a point on a manifold consists of.
+
+        For most manifolds, which represent points as (potentially
+        multi-dimensional) arrays, this will be 1, but other manifolds might
+        represent points as tuples or lists of arrays. In this case,
+        `point_format` describes how many elements such tuples/lists contain.
+        """
+        return self._point_format
 
     # Manifold properties that subclasses can define
 

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -25,14 +25,18 @@ class Manifold(metaclass=abc.ABCMeta):
     methods in this class have equivalents in Manopt with the same name).
     """
 
-    def __init__(self, name, dimension, point_format=1):
+    def __init__(self, name, dimension, point_layout=1):
         assert isinstance(dimension, (int, np.integer)), \
             "dimension must be an integer"
-        assert isinstance(point_format, int) and point_format > 0, \
-            "point_format must be a positive integer"
+        assert ((isinstance(point_layout, int) and point_layout > 0) or
+                (isinstance(point_layout, (list, tuple)) and
+                 all(np.array(point_layout) > 0))), \
+            ("'point_layout' must be a positive integer or a sequence of "
+             "positive integers")
+
         self._name = name
         self._dimension = dimension
-        self._point_format = point_format
+        self._point_layout = point_layout
 
     def __str__(self):
         """Returns a string representation of the particular manifold."""
@@ -47,15 +51,15 @@ class Manifold(metaclass=abc.ABCMeta):
         return self._dimension
 
     @property
-    def point_format(self):
+    def point_layout(self):
         """The number of elements a point on a manifold consists of.
 
         For most manifolds, which represent points as (potentially
         multi-dimensional) arrays, this will be 1, but other manifolds might
         represent points as tuples or lists of arrays. In this case,
-        `point_format` describes how many elements such tuples/lists contain.
+        `point_layout` describes how many elements such tuples/lists contain.
         """
-        return self._point_format
+        return self._point_layout
 
     # Manifold properties that subclasses can define
 

--- a/pymanopt/manifolds/product.py
+++ b/pymanopt/manifolds/product.py
@@ -17,8 +17,8 @@ class Product(Manifold):
         name = ("Product manifold: {:s}".format(
                 " x ".join([str(man) for man in manifolds])))
         dimension = np.sum([man.dim for man in manifolds])
-        point_format = (manifold.point_format for manifold in manifolds)
-        super().__init__(name, dimension, point_format=point_format)
+        point_layout = tuple(manifold.point_layout for manifold in manifolds)
+        super().__init__(name, dimension, point_layout=point_layout)
 
     def __setattr__(self, key, value):
         if hasattr(self, key):

--- a/pymanopt/tools/__init__.py
+++ b/pymanopt/tools/__init__.py
@@ -19,14 +19,15 @@ class ndarraySequenceMixin:
     __array_ufunc__ = None  # Available since numpy 1.13
 
 
-def unpack_singleton_iterable_return_value(function):
+def unpack_singleton_sequence_return_value(function):
     """Function decorator which unwraps the return value of ``function`` if it
     is a sequence containing only a single element.
     """
     @functools.wraps(function)
     def wrapper(*args):
         result = function(*args)
-        assert isinstance(result, (list, tuple)) and len(result) == 1
+        if not isinstance(result, (list, tuple)) or len(result) != 1:
+            raise ValueError("Function did not return a singleton sequence")
         return result[0]
     return wrapper
 

--- a/pymanopt/tools/__init__.py
+++ b/pymanopt/tools/__init__.py
@@ -93,3 +93,14 @@ def group_return_values(function, signature):
             i += n
         return groups
     return inner
+
+
+def unpack_singleton_iterable_return_value(function):
+    """Function decorator which unwraps^
+    """
+    @functools.wraps(function)
+    def wrapper(*args):
+        result = function(*args)
+        assert isinstance(result, (list, tuple))
+        return result[0]
+    return wrapper

--- a/pymanopt/tools/__init__.py
+++ b/pymanopt/tools/__init__.py
@@ -104,3 +104,10 @@ def unpack_singleton_iterable_return_value(function):
         assert isinstance(result, (list, tuple))
         return result[0]
     return wrapper
+
+
+def bisect_iterable(iterable):
+    num_items = len(iterable)
+    if num_items % 2 == 1:
+        raise ValueError("Iterable must have an even number of elements")
+    return iterable[:num_items // 2], iterable[num_items // 2:]

--- a/pymanopt/tools/__init__.py
+++ b/pymanopt/tools/__init__.py
@@ -19,95 +19,20 @@ class ndarraySequenceMixin:
     __array_ufunc__ = None  # Available since numpy 1.13
 
 
-def _flatten_arguments_from_signature(arguments, signature):
-    flattened_arguments = []
-    for i, group in enumerate(signature):
-        if isinstance(group, (list, tuple)):
-            flattened_arguments.extend(arguments[i])
-        else:
-            flattened_arguments.append(arguments[i])
-    return tuple(flattened_arguments)
-
-
-def flatten_arguments(arguments, signature=None):
-    """Takes a sequence `arguments` containing tuples/lists of arguments or
-    unary arguments and returns a flattened tuple of arguments, e.g.
-    `flatten_arguments([1, 2], 3)` produces the tuple `(1, 2, 3)`. If the
-    nesting cannot be inferred from the types of objects contained in
-    `arguments` itself, one may pass the optional argument `signature` instead.
-    """
-    if signature is not None:
-        return _flatten_arguments_from_signature(arguments, signature)
-
-    flattened_arguments = []
-    for argument in arguments:
-        if isinstance(argument, (list, tuple)):
-            flattened_arguments.extend(argument)
-        else:
-            flattened_arguments.append(argument)
-    return tuple(flattened_arguments)
-
-
-def unpack_arguments(function, signature=None):
-    """A decorator which wraps a function accepting a single sequence of
-    arguments and calls the function with unpacked arguments. If given, the
-    call arguments are unpacked according to the `signature' which is a string
-    representation of the argument grouping/nesting, e.g. `(("x", "y"), "z")'.
-    """
-    @functools.wraps(function)
-    def inner(arguments):
-        return function(*flatten_arguments(arguments, signature=signature))
-    return inner
-
-
-def group_return_values(function, signature):
-    """Returns a wrapped version of `function` which groups the return values
-    of the function in the same way as defined by the signature given by
-    `signature`.
-    """
-    if len(signature) == 1:
-        @functools.wraps(function)
-        def inner(*args):
-            return function(*args)
-        return inner
-
-    group_sizes = []
-    for element in signature:
-        if isinstance(element, (list, tuple)):
-            group_sizes.append(len(element))
-        else:
-            group_sizes.append(1)
-
-    @functools.wraps(function)
-    def inner(*args):
-        # TODO(nkoep): This function might be hot. Can we come up with a more
-        #              elegant implementation?
-        return_values = function(*args)
-        groups = []
-        i = 0
-        for n in group_sizes:
-            if n == 1:
-                groups.append(return_values[i])
-            else:
-                groups.append(return_values[i:i+n])
-            i += n
-        return groups
-    return inner
-
-
 def unpack_singleton_iterable_return_value(function):
-    """Function decorator which unwraps^
+    """Function decorator which unwraps the return value of ``function`` if it
+    is a sequence containing only a single element.
     """
     @functools.wraps(function)
     def wrapper(*args):
         result = function(*args)
-        assert isinstance(result, (list, tuple))
+        assert isinstance(result, (list, tuple)) and len(result) == 1
         return result[0]
     return wrapper
 
 
-def bisect_iterable(iterable):
-    num_items = len(iterable)
+def bisect_sequence(sequence):
+    num_items = len(sequence)
     if num_items % 2 == 1:
-        raise ValueError("Iterable must have an even number of elements")
-    return iterable[:num_items // 2], iterable[num_items // 2:]
+        raise ValueError("Sequence must have an even number of elements")
+    return sequence[:num_items // 2], sequence[num_items // 2:]

--- a/tests/test_backends/test_autograd.py
+++ b/tests/test_backends/test_autograd.py
@@ -21,7 +21,7 @@ class TestNaryFunction(_backend_tests.TestNaryFunction):
 
         @Autograd
         def cost(x, y):
-            return np.dot(x, y)
+            return x @ y
 
         self.cost = cost
 
@@ -30,7 +30,7 @@ class TestNaryParameterGrouping(_backend_tests.TestNaryParameterGrouping):
     def setUp(self):
         super().setUp()
 
-        @Autograd(("x", "y"), "z")
+        @Autograd
         def cost(x, y, z):
             return np.sum(x ** 2 + y + z ** 3)
 

--- a/tests/test_backends/test_backend_tools.py
+++ b/tests/test_backends/test_backend_tools.py
@@ -1,27 +1,36 @@
 import unittest
 
-from pymanopt.tools import flatten_arguments
+from pymanopt.tools import (
+    bisect_sequence, unpack_singleton_sequence_return_value
+)
 
 
 class TestArgumentFlattening(unittest.TestCase):
-    def _test_flatten_arguments(
-            self, arguments, correctly_flattened_arguments):
-        flattened_arguments = flatten_arguments(arguments)
-        self.assertEqual(flattened_arguments, correctly_flattened_arguments)
+    def test_bisect_sequence(self):
+        sequence = range(10)
+        half1, half2 = bisect_sequence(sequence)
+        self.assertEqual(half1, range(5))
+        self.assertEqual(half2, range(5, 10))
+        with self.assertRaises(ValueError):
+            bisect_sequence(range(11))
 
-        flattened_arguments_with_signature_hint = flatten_arguments(
-            arguments, signature=arguments)
-        self.assertEqual(flattened_arguments_with_signature_hint,
-                         correctly_flattened_arguments)
+    def test_unpack_singleton_sequence_return_value(self):
+        @unpack_singleton_sequence_return_value
+        def f():
+            return (1,)
 
-    def test_single_argument(self):
-        arguments = ("x",)
-        self._test_flatten_arguments(arguments, arguments)
+        self.assertEqual(f(), 1)
 
-    def test_multiple_arguments(self):
-        arguments = ("x", "y", "z")
-        self._test_flatten_arguments(arguments, arguments)
+        @unpack_singleton_sequence_return_value
+        def g():
+            return (1, 2)
 
-    def test_nested_arguments(self):
-        arguments = (("x", "y"), "z")
-        self._test_flatten_arguments(arguments, ("x", "y", "z"))
+        with self.assertRaises(ValueError):
+            g()
+
+        @unpack_singleton_sequence_return_value
+        def h():
+            return None
+
+        with self.assertRaises(ValueError):
+            h()

--- a/tests/test_backends/test_callable.py
+++ b/tests/test_backends/test_callable.py
@@ -7,29 +7,33 @@ from .._test import TestCase
 
 class TestCallableBackend(TestCase):
     def setUp(self):
+        self.n = 10
+
         @Callable
         def nary_cost(x, y):
             return np.sum(x * y)
 
         self.cost = self.nary_cost = nary_cost
 
-        @Callable(("x", "y"), "z")
+        @Callable
         def nested_nary_cost(x, y, z):
             return np.sum(x ** 2 * y + 3 * z)
 
         self.nested_nary_cost = nested_nary_cost
 
     def test_nary_cost_function(self):
-        x, y = [rnd.randn(10) for _ in range(2)]
-        np_testing.assert_allclose(np.sum(x * y), self.nary_cost((x, y)))
+        n = self.n
+        x, y = [rnd.randn(n) for _ in range(2)]
+        np_testing.assert_allclose(np.sum(x * y), self.nary_cost(x, y))
 
     def test_nested_nary_cost_function(self):
-        x, y, z = [rnd.randn(10) for _ in range(3)]
+        n = self.n
+        x, y, z = [rnd.randn(n) for _ in range(3)]
         np_testing.assert_allclose(np.sum(x ** 2 * y + 3 * z),
-                                   self.nested_nary_cost(((x, y), z)))
+                                   self.nested_nary_cost(x, y, z))
 
     def test_gradient_hessian_exceptions(self):
         with self.assertRaises(NotImplementedError):
             self.cost.compute_gradient()
         with self.assertRaises(NotImplementedError):
-            self.cost.compute_hessian()
+            self.cost.compute_hessian_vector_product()

--- a/tests/test_backends/test_pytorch.py
+++ b/tests/test_backends/test_pytorch.py
@@ -30,7 +30,7 @@ class TestNaryParameterGrouping(_backend_tests.TestNaryParameterGrouping):
     def setUp(self):
         super().setUp()
 
-        @PyTorch(("x", "y"), "z")
+        @PyTorch
         def cost(x, y, z):
             return torch.sum(x ** 2 + y + z ** 3)
 

--- a/tests/test_backends/test_tensorflow.py
+++ b/tests/test_backends/test_tensorflow.py
@@ -50,7 +50,7 @@ class TestNaryParameterGrouping(_backend_tests.TestNaryParameterGrouping):
         y = tf.Variable(tf.zeros(n, dtype=np.float64), name="y")
         z = tf.Variable(tf.zeros(n, dtype=np.float64), name="z")
 
-        @TensorFlow((x, y), z)
+        @TensorFlow(x, y, z)
         def cost(x, y, z):
             return tf.reduce_sum(x ** 2 + y + z ** 3)
 
@@ -79,7 +79,7 @@ class TestMatrix(_backend_tests.TestMatrix):
         m = self.m
         n = self.n
 
-        X = tf.Variable(tf.zeros([m, n], dtype=np.float64))
+        X = tf.Variable(tf.zeros((m, n), dtype=np.float64))
 
         @TensorFlow(X)
         def cost(X):

--- a/tests/test_backends/test_theano.py
+++ b/tests/test_backends/test_theano.py
@@ -40,7 +40,7 @@ class TestNaryParameterGrouping(_backend_tests.TestNaryParameterGrouping):
         y = T.vector()
         z = T.vector()
 
-        @Theano((x, y), z)
+        @Theano(x, y, z)
         def cost(x, y, z):
             return T.sum(x ** 2 + y + z ** 3)
 
@@ -75,7 +75,7 @@ class TestVector(_backend_tests.TestVector):
             return T.exp(T.sum(X ** 2))
 
         # And check that all is still well
-        hess = cost.compute_hessian()
+        hess = cost.compute_hessian_vector_product()
 
         np_testing.assert_allclose(self.correct_hess, hess(self.Y, self.A))
 
@@ -111,7 +111,7 @@ class TestMatrix(_backend_tests.TestMatrix):
             return T.exp(T.sum(X ** 2))
 
         # And check that all is still well
-        hess = cost.compute_hessian()
+        hess = cost.compute_hessian_vector_product()
 
         np_testing.assert_allclose(self.correct_hess, hess(self.Y, self.A))
 
@@ -147,7 +147,7 @@ class TestTensor3(_backend_tests.TestTensor3):
             return T.exp(T.sum(X ** 2))
 
         # And check that all is still well
-        hess = cost.compute_hessian()
+        hess = cost.compute_hessian_vector_product()
 
         np_testing.assert_allclose(self.correct_hess, hess(self.Y, self.A))
 
@@ -189,9 +189,9 @@ class TestMixed(_backend_tests.TestMixed):
         cost = Theano(x, y, z)(lambda x, y, z: f)
 
         # And check that all is still well
-        hess = cost.compute_hessian()
+        hess = cost.compute_hessian_vector_product()
 
-        h = hess(self.y, self.a)
+        h = hess(*self.y, *self.a)
         for k in range(len(h)):
             np_testing.assert_allclose(self.correct_hess[k], h[k])
 

--- a/tests/test_problem_backend_interface.py
+++ b/tests/test_problem_backend_interface.py
@@ -1,0 +1,76 @@
+import autograd.numpy as np
+import numpy.testing as np_testing
+
+import pymanopt
+from pymanopt.manifolds import Euclidean, FixedRankEmbedded, Product
+from ._test import TestCase
+
+
+class TestProblemBackendInterface(TestCase):
+    def setUp(self):
+        self.m = m = 20
+        self.n = n = 10
+        self.rank = rank = 3
+
+        A = np.random.randn(m, n)
+
+        @pymanopt.function.Autograd
+        def cost(u, s, vt, x):
+            return np.linalg.norm(((u * s) @ vt - A) @ x) ** 2
+
+        self.cost = cost
+        self.gradient = self.cost.compute_gradient()
+        self.hvp = self.cost.compute_hessian_vector_product()
+
+        self.manifold = Product([FixedRankEmbedded(m, n, rank), Euclidean(n)])
+        self.problem = pymanopt.Problem(self.manifold, self.cost)
+
+    def test_cost_function(self):
+        (u, s, vt), x = self.manifold.rand()
+        self.cost(u, s, vt, x)
+
+    def test_gradient(self):
+        (u, s, vt), x = self.manifold.rand()
+        gu, gs, gvt, gx = self.gradient(u, s, vt, x)
+        self.assertEqual(gu.shape, (self.m, self.rank))
+        self.assertEqual(gs.shape, (self.rank,))
+        self.assertEqual(gvt.shape, (self.rank, self.n))
+        self.assertEqual(gx.shape, (self.n,))
+
+    def test_hessian_vector_product(self):
+        (u, s, vt), x = self.manifold.rand()
+        (a, b, c), d = self.manifold.rand()
+        hu, hs, hvt, hx = self.hvp(u, s, vt, x, a, b, c, d)
+        self.assertEqual(hu.shape, (self.m, self.rank))
+        self.assertEqual(hs.shape, (self.rank,))
+        self.assertEqual(hvt.shape, (self.rank, self.n))
+        self.assertEqual(hx.shape, (self.n,))
+
+    def test_problem_cost(self):
+        cost = self.problem.cost
+        X = self.manifold.rand()
+        (u, s, vt), x = X
+        np_testing.assert_allclose(cost(X), self.cost(u, s, vt, x))
+
+    def test_problem_egrad(self):
+        egrad = self.problem.egrad
+        X = self.manifold.rand()
+        (u, s, vt), x = X
+        G = egrad(X)
+        (gu, gs, gvt), gx = G
+        for ga, gb in zip((gu, gs, gvt, gx), self.gradient(u, s, vt, x)):
+            np_testing.assert_allclose(ga, gb)
+
+    def test_problem_hessian_vector_product(self):
+        ehess = self.problem.ehess
+        X = self.manifold.rand()
+        U = self.manifold.rand()
+        H = ehess(X, U)
+
+        (u, s, vt), x = X
+        (a, b, c), d = U
+
+        (hu, hs, hvt), hx = H
+        for ha, hb in zip((hu, hs, hvt, hx),
+                          self.hvp(u, s, vt, x, a, b, c, d)):
+            np_testing.assert_allclose(ha, hb)


### PR DESCRIPTION
This is the second attempt to clean up the autodiff backend. As I was preparing #102, I noticed various rough edges in the previous rewrite due to our attempts to cram too much logic/magic/functionality into the autodiff backends. Note that for testing purposes, this PR is based on #102, which should therefore be merged first. This will also simplify review of the PR as a lot of the example-related changes will disappear after #102 is merged.

The most severe limitation was that Hessian-vector product functions could not be decorated with any backend decorator at all. Each backend would always treat functions of the form `ehess(x, u)` as nary functions whose arguments would be wrapped in a tuple since this is how solvers call cost functions and gradients on product manifolds. For the `Callable` backend, this meant one had to define hvps as regular callables, potentially unpacking the call arguments manually, which is something I wanted to avoid by redesigning the backend logic. For the other backends things were arguably even worse as they didn't support explicit hvps at all, only autodiff'd versions derived from provided cost functions.

Here's the rundown of the PR:
- Functions decorated with any of the backend decorators exported from `pymanopt.function` now always retain their original call signature. This is much more natural than the previous implementation, where a function like 
```python
@pymanopt.function.Autograd
def cost(x, y): return x @ y
```
had to be called as `cost((x, y))` rather than `cost(x, y)`. The same applies to autodiff'd `egrad` and `ehess` functions. In the above example, the hvp signature now reads `ehess(x, y, u, v)`, i.e., the way you would define it manually using the `Callable` backend.
- Nested signature hints such as `@pymanopt.function.Theano((x, y), z)` are never required anymore. The information is instead inferred from the manifold inside the `Problem` class.
- When passing functions like `cost`, `egrad`, `ehess`, etc. to the `Problem` class, these functions are wrapped internally. This pulls out a lot of repeated/redundant function wrapping logic from the backends and moves it into the `Problem` class. The wrapped versions of the provided functions will be returned via the `cost`, `egrad`, `ehess`, etc. properties as used internally by solvers. For instance, `problem.ehess` _always_ accepts 2 arguments, even if a point on a manifold is represented by more than one array. The wrapper will unwrap the call arguments and forward arguments appropriately to the wrapped function. The same goes for return values of gradient and hvps, which may have to be conceptually grouped as nested tuples.
- To facilitate wrapping of call arguments and return values, the `Manifold` base class now provides a `point_layout` property. For regular manifolds, this is a positive integer delineating how many elements describe a point on the manifold. In most cases, this is simply 1, the default value set in the `Manifold` base class. Notable exceptions are the `FixedRankEmbedded` manifold, which represents points as tuples of 3 arrays. The other exception is the `Product` manifold, which defines its `point_layout` as a tuple of the point layouts of the manifolds involved in the product.