### PR TITLE
Add python 3.8, 3.9 to ci (for testing).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Tests'
         run: nose2 tests --verbose --with-coverage
       - name: 'Coveralls'
-        if: ${{ matrix.python-version == '3.7' }}
+        if: ${{ matrix.python-version == '3.9' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 'Set up Python'
         uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: 'Checkout'
         uses: actions/checkout@v2
       - name: 'Pip upgrade'


### PR DESCRIPTION
Inclusion of python 3.10 is pending on all dependencies having the needed support (for example, [tensorflow has no python 3.10 support yet](https://discuss.tensorflow.org/t/support-python-3-10/124)).