### PR TITLE
Add ColumnPrinter helper class

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,25 @@
+# Codacy (and in turn prospector) apparently enables _all_ rules available in
+# pydocstyle by default (see
+# https://community.codacy.com/t/d203-and-d213-are-not-required-by-pep-257/237/7).
+# This configures pep257 on prospector the ues the default conventions
+# according to the pep257 docs (see
+# http://www.pydocstyle.org/en/stable/error_codes.html#default-conventions).
+pep257:
+  disable:
+    - D203
+    - D212
+    - D213
+    - D214
+    - D215
+    - D404
+    - D405
+    - D406
+    - D407
+    - D408
+    - D409
+    - D410
+    - D411
+    - D413
+    - D415
+    - D416
+    - D417

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,9 +1,11 @@
 # Codacy (and in turn prospector) apparently enables _all_ rules available in
-# pydocstyle by default (see
-# https://community.codacy.com/t/d203-and-d213-are-not-required-by-pep-257/237/7).
-# This configures pep257 on prospector the ues the default conventions
-# according to the pep257 docs (see
-# http://www.pydocstyle.org/en/stable/error_codes.html#default-conventions).
+# pydocstyle by default [1].
+# This configures pep257 on prospector to use the default conventions according
+# to the pep257 docs [2].
+#
+# [1] https://community.codacy.com/t/d203-and-d213-are-not-required-by-pep-257/237/7)
+# [2] http://www.pydocstyle.org/en/stable/error_codes.html#default-conventions
+
 pep257:
   disable:
     - D203

--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -6,6 +6,7 @@ import numpy as np
 from pymanopt import tools
 from pymanopt.solvers.linesearch import LineSearchAdaptive
 from pymanopt.solvers.solver import Solver
+from pymanopt.tools import printer
 
 
 # TODO: Use Python's enum module.
@@ -83,15 +84,20 @@ class ConjugateGradient(Solver):
         if x is None:
             x = man.rand()
 
-        # Initialize iteration counter and timer
-        iter = 0
-        stepsize = np.nan
-        time0 = time.time()
-
         if verbosity >= 1:
             print("Optimizing...")
         if verbosity >= 2:
-            print(" iter\t\t   cost val\t    grad. norm")
+            column_printer = printer.ColumnPrinter(
+                columns=[
+                    ("Iteration", "5d"),
+                    ("Cost", "+.16e"),
+                    ("Gradient norm", ".8e"),
+                ]
+            )
+        else:
+            column_printer = printer.VoidPrinter()
+
+        column_printer.print_header()
 
         # Calculate initial cost-related quantities
         cost = objective(x)
@@ -108,9 +114,13 @@ class ConjugateGradient(Solver):
                                          'orth_value': self._orth_value,
                                          'linesearcher': linesearch})
 
+        # Initialize iteration counter and timer
+        iter = 0
+        stepsize = np.nan
+        time0 = time.time()
+
         while True:
-            if verbosity >= 2:
-                print("%5d\t%+.16e\t%.8e" % (iter, cost, gradnorm))
+            column_printer.print_row([iter, cost, gradnorm])
 
             if self._logverbosity >= 2:
                 self._append_optlog(iter, x, cost, gradnorm=gradnorm)

--- a/pymanopt/solvers/conjugate_gradient.py
+++ b/pymanopt/solvers/conjugate_gradient.py
@@ -87,9 +87,10 @@ class ConjugateGradient(Solver):
         if verbosity >= 1:
             print("Optimizing...")
         if verbosity >= 2:
+            iter_format_length = int(np.log10(self._maxiter)) + 1
             column_printer = printer.ColumnPrinter(
                 columns=[
-                    ("Iteration", "5d"),
+                    ("Iteration", f"{iter_format_length}d"),
                     ("Cost", "+.16e"),
                     ("Gradient norm", ".8e"),
                 ]

--- a/pymanopt/solvers/particle_swarm.py
+++ b/pymanopt/solvers/particle_swarm.py
@@ -102,9 +102,10 @@ class ParticleSwarm(Solver):
         xbest = x[imin]
 
         if verbosity >= 2:
+            iter_format_length = int(np.log10(self._maxiter)) + 1
             column_printer = printer.ColumnPrinter(
                 columns=[
-                    ("Iteration", "5d"),
+                    ("Iteration", f"{iter_format_length}d"),
                     ("Cost evaluations", "7d"),
                     ("Best cost", "+.8e"),
                 ]

--- a/pymanopt/solvers/particle_swarm.py
+++ b/pymanopt/solvers/particle_swarm.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.random as rnd
 
 from pymanopt.solvers.solver import Solver
+from pymanopt.tools import printer
 
 
 class ParticleSwarm(Solver):
@@ -100,19 +101,30 @@ class ParticleSwarm(Solver):
         fbest = costs[imin]
         xbest = x[imin]
 
+        if verbosity >= 2:
+            column_printer = printer.ColumnPrinter(
+                columns=[
+                    ("Iteration", "5d"),
+                    ("Cost evaluations", "7d"),
+                    ("Best cost", "+.8e"),
+                ]
+            )
+        else:
+            column_printer = printer.VoidPrinter()
+
+        column_printer.print_header()
+
+        self._start_optlog()
+
         # Iteration counter (at any point, iter is the number of fully executed
         # iterations so far).
         iter = 0
-
         time0 = time.time()
-
-        self._start_optlog()
 
         while True:
             iter += 1
 
-            if verbosity >= 2:
-                print("Cost evals: %7d\tBest cost: %+.8e" % (costevals, fbest))
+            column_printer.print_row([iter, costevals, fbest])
 
             # Stop if any particle triggers a stopping criterion.
             for i, xi in enumerate(x):

--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -1,6 +1,8 @@
 import time
 from copy import deepcopy
 
+import numpy as np
+
 from pymanopt.solvers.linesearch import LineSearchBackTracking
 from pymanopt.solvers.solver import Solver
 from pymanopt.tools import printer
@@ -61,9 +63,10 @@ class SteepestDescent(Solver):
         if verbosity >= 1:
             print("Optimizing...")
         if verbosity >= 2:
+            iter_format_length = int(np.log10(self._maxiter)) + 1
             column_printer = printer.ColumnPrinter(
                 columns=[
-                    ("Iteration", "5d"),
+                    ("Iteration", f"{iter_format_length}d"),
                     ("Cost", "+.16e"),
                     ("Gradient norm", ".8e"),
                 ]

--- a/pymanopt/solvers/steepest_descent.py
+++ b/pymanopt/solvers/steepest_descent.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 
 from pymanopt.solvers.linesearch import LineSearchBackTracking
 from pymanopt.solvers.solver import Solver
+from pymanopt.tools import printer
 
 
 class SteepestDescent(Solver):
@@ -57,15 +58,27 @@ class SteepestDescent(Solver):
         if x is None:
             x = man.rand()
 
-        # Initialize iteration counter and timer
-        iter = 0
-        time0 = time.time()
-
+        if verbosity >= 1:
+            print("Optimizing...")
         if verbosity >= 2:
-            print(" iter\t\t   cost val\t    grad. norm")
+            column_printer = printer.ColumnPrinter(
+                columns=[
+                    ("Iteration", "5d"),
+                    ("Cost", "+.16e"),
+                    ("Gradient norm", ".8e"),
+                ]
+            )
+        else:
+            column_printer = printer.VoidPrinter()
+
+        column_printer.print_header()
 
         self._start_optlog(extraiterfields=['gradnorm'],
                            solverparams={'linesearcher': linesearch})
+
+        # Initialize iteration counter and timer
+        iter = 0
+        time0 = time.time()
 
         while True:
             # Calculate new cost, grad and gradnorm
@@ -74,8 +87,7 @@ class SteepestDescent(Solver):
             gradnorm = man.norm(x, grad)
             iter = iter + 1
 
-            if verbosity >= 2:
-                print("%5d\t%+.16e\t%.8e" % (iter, cost, gradnorm))
+            column_printer.print_row([iter, cost, gradnorm])
 
             if self._logverbosity >= 2:
                 self._append_optlog(iter, x, cost, gradnorm=gradnorm)

--- a/pymanopt/tools/printer.py
+++ b/pymanopt/tools/printer.py
@@ -1,0 +1,81 @@
+from typing import Any, Iterable, List, Optional, Tuple
+
+
+class VoidPrinter:
+    """Printer that prints its arguments to the void."""
+
+    def print_header(self):
+        pass
+
+    def print_row(self, values: Iterable[Any]):
+        pass
+
+
+def print_list(values: List[str]):
+    """Join and print the values given in the ``values`` list."""
+    print("".join(values))
+
+
+class ColumnPrinter(VoidPrinter):
+    """Printer that formats values in a column layout.
+
+    Args:
+        columns: A list of (column name, format string) tuples.
+        placeholder_values: Placeholder values to use when calculating the
+            column widths.
+        column_padding: Number of spaces to insert between columns.
+    """
+
+    def __init__(
+        self,
+        *,
+        columns: List[Tuple[str, str]],
+        placeholder_values: Optional[List[Any]] = None,
+        column_padding: int = 4,
+    ):
+        self.column_names, format_strings = zip(*columns)
+        self.column_formatters = [
+            f"{{value:{format_string}}}" for format_string in format_strings
+        ]
+        self.column_padding = column_padding
+
+        # Compute the column widths.
+        if placeholder_values is None:
+            placeholder_values = [0] * len(self.column_names)
+        self.column_widths = [
+            max(
+                len(column),
+                len(formatter.format(value=value)),
+            )
+            + self.column_padding
+            for column, formatter, value in zip(
+                self.column_names, self.column_formatters, placeholder_values
+            )
+        ]
+
+    def print_header(self):
+        """Print a formatted header line."""
+        segments = [
+            (
+                column + " " * (column_width - len(column)),
+                "-" * (column_width - self.column_padding)
+                + " " * self.column_padding,
+            )
+            for column, column_width in zip(
+                self.column_names, self.column_widths
+            )
+        ]
+        header_segments, underline_segments = zip(*segments)
+        print_list(header_segments)
+        print_list(underline_segments)
+
+    def print_row(self, values: Iterable[Any]):
+        """Print ``values`` formatted as a row."""
+        column_strings = [
+            formatter.format(value=value)
+            + " " * (column_width - len(formatter.format(value=value)))
+            for formatter, column_width, value in zip(
+                self.column_formatters, self.column_widths, values
+            )
+        ]
+        print_list(column_strings)

--- a/pymanopt/tools/printer.py
+++ b/pymanopt/tools/printer.py
@@ -19,6 +19,7 @@ def print_list(values: List[str]):
     """Print a formatted list of values.
 
     Join and print the values given in the ``values`` list.
+
     Args:
         values: A list of values to join and print.
     """

--- a/pymanopt/tools/printer.py
+++ b/pymanopt/tools/printer.py
@@ -2,17 +2,26 @@ from typing import Any, Iterable, List, Optional, Tuple
 
 
 class VoidPrinter:
-    """Printer that prints its arguments to the void."""
+    """Printer that prints nothing."""
 
     def print_header(self):
-        pass
+        """Print nothing."""
 
     def print_row(self, values: Iterable[Any]):
-        pass
+        """Print nothing.
+
+        Args:
+            values: The values not to print.
+        """
 
 
 def print_list(values: List[str]):
-    """Join and print the values given in the ``values`` list."""
+    """Print a formatted list of values.
+
+    Join and print the values given in the ``values`` list.
+    Args:
+        values: A list of values to join and print.
+    """
     print("".join(values))
 
 
@@ -24,7 +33,18 @@ class ColumnPrinter(VoidPrinter):
         placeholder_values: Placeholder values to use when calculating the
             column widths.
         column_padding: Number of spaces to insert between columns.
+
+    Attributes:
+        column_names: Tuple of column names (headers).
+        column_formatters: Tuple of column formatting strings.
+        column_padding: The number of spaces used to pad columns.
+        column_widths: Tuple of calculated column widths.
     """
+
+    column_names: Tuple[str]
+    column_formatters: Tuple[str]
+    column_padding: int
+    column_widths: Tuple[str]
 
     def __init__(
         self,
@@ -33,25 +53,29 @@ class ColumnPrinter(VoidPrinter):
         placeholder_values: Optional[List[Any]] = None,
         column_padding: int = 4,
     ):
-        self.column_names, format_strings = zip(*columns)
-        self.column_formatters = [
-            f"{{value:{format_string}}}" for format_string in format_strings
-        ]
+        self.column_names, format_strings = map(tuple, zip(*columns))
+        self.column_formatters = tuple(
+            [f"{{value:{format_string}}}" for format_string in format_strings]
+        )
         self.column_padding = column_padding
 
         # Compute the column widths.
         if placeholder_values is None:
             placeholder_values = [0] * len(self.column_names)
-        self.column_widths = [
-            max(
-                len(column),
-                len(formatter.format(value=value)),
-            )
-            + self.column_padding
-            for column, formatter, value in zip(
-                self.column_names, self.column_formatters, placeholder_values
-            )
-        ]
+        self.column_widths = tuple(
+            [
+                max(
+                    len(column),
+                    len(formatter.format(value=value)),
+                )
+                + self.column_padding
+                for column, formatter, value in zip(
+                    self.column_names,
+                    self.column_formatters,
+                    placeholder_values,
+                )
+            ]
+        )
 
     def print_header(self):
         """Print a formatted header line."""
@@ -70,7 +94,11 @@ class ColumnPrinter(VoidPrinter):
         print_list(underline_segments)
 
     def print_row(self, values: Iterable[Any]):
-        """Print ``values`` formatted as a row."""
+        """Print formatted as a row.
+
+        Args:
+            values: The values to print.
+        """
         column_strings = [
             formatter.format(value=value)
             + " " * (column_width - len(formatter.format(value=value)))


### PR DESCRIPTION
This PR adds a small helper class to print data in a column-wise format during optimization. This replaces the manual column formatting in the steepest descent, conjugate gradient, and particle swarm optimization algorithms. Other solvers will be migrated to the new class at a later point. The printer produces output of the following form:

```raw
Iteration    Cost                       Gradient norm     
---------    -----------------------    --------------    
    1        +1.1041943339110254e+00    5.65626470e-01    
    2        +5.2849633289004549e-01    8.90742722e-01    
    3        -8.0741058657312559e-01    2.23937710e+00    
    4        -1.2667369971251599e+00    1.59671326e+00    
    5        -1.4100298597091827e+00    1.11228845e+00    
    6        -1.5219408277812518e+00    2.45507203e-01    
    7        -1.5269956262562037e+00    6.81712914e-02    
    8        -1.5273114803528722e+00    3.40941735e-02    
    9        -1.5273905588875458e+00    1.70222768e-02    
   10        -1.5274100956128616e+00    8.61140952e-03    
   11        -1.5274154319869742e+00    3.90706916e-03    
   12        -1.5274156215853911e+00    3.62943715e-03    
   13        -1.5274162595154515e+00    2.47643413e-03    
   14        -1.5274168030608213e+00    3.66399834e-04    
   15        -1.5274168133150441e+00    1.45206426e-04    
   16        -1.5274168150024663e+00    4.96264414e-05    
   17        -1.5274168150487220e+00    4.41850266e-05    
   18        -1.5274168151853666e+00    2.10790084e-05    
   19        -1.5274168152060719e+00    1.46909061e-05    
   20        -1.5274168152255612e+00    8.62892265e-07    
Terminated - min grad norm reached after 20 iterations, 0.01 seconds.
```

The previous solution relied on tabs to format columns which made it hard to use the output of solvers in doctests. For the upcoming merge of #156, this printer class relies solely on spaces and exact column padding.