### PR TITLE
Migrate to f-strings and matrix multiplication operator

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # Pymanopt TODO List
 
-- Development
-  - Integrate flake8-docstrings (add 'docstring-convention = numpy' in [flake8]
-    section of .flake8 file)
-
 - **Improve test coverage**
 
 - Manifolds:
@@ -12,10 +8,3 @@
 - Solvers
   - nelder_mead [@31](./pymanopt/solvers/nelder_mead.py#L31): need to decide what to do about the TR iterations
   - Solvers cast to np.array before returning
-
-- Tools:
-  - autodiff autograd: move type checking outside of compiled function
-  - autodiff/_autograd: fix product manifold when one or more of the manifolds is FixedRankEmbedded
-
-- Misc:
-  - always use "".format rather than "%s" % "bla"

--- a/examples/_tools.py
+++ b/examples/_tools.py
@@ -21,6 +21,6 @@ class ExampleRunner:
         if not quiet:
             print(self._name)
             print("-" * len(self._name))
-            print("Using '{:s}' backend".format(backend))
+            print(f"Using '{backend}' backend")
             print()
         self._run_function(backend=backend, quiet=quiet)

--- a/examples/advanced/check_gradient.py
+++ b/examples/advanced/check_gradient.py
@@ -39,7 +39,7 @@ def create_cost_egrad(manifold, matrix, backend):
         def cost(x):
             return -tf.tensordot(x, tf.tensordot(matrix, x, axes=1), axes=1)
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad
 

--- a/examples/closest_unit_norm_column_approximation.py
+++ b/examples/closest_unit_norm_column_approximation.py
@@ -39,7 +39,7 @@ def create_cost_egrad(manifold, matrix, backend):
         def cost(X):
             return 0.5 * tf.reduce_sum((X - matrix) ** 2)
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad
 

--- a/examples/dominant_eigenvector.py
+++ b/examples/dominant_eigenvector.py
@@ -39,7 +39,7 @@ def create_cost_egrad(manifold, matrix, backend):
         def cost(x):
             return -tf.tensordot(x, tf.tensordot(matrix, x, axes=1), axes=1)
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad
 

--- a/examples/dominant_invariant_subspace.py
+++ b/examples/dominant_invariant_subspace.py
@@ -50,7 +50,7 @@ def create_cost_egrad_ehess(manifold, matrix, backend):
         def egrad(X):
             return -tf.matmul(matrix + matrix.T, X)
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad, ehess
 

--- a/examples/low_rank_matrix_approximation.py
+++ b/examples/low_rank_matrix_approximation.py
@@ -48,7 +48,7 @@ def create_cost_egrad(manifold, matrix, backend):
             X = tf.matmul(u, tf.matmul(tf.linalg.diag(s), vt))
             return tf.norm(X - matrix) ** 2
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad
 
@@ -80,7 +80,7 @@ def run(backend=SUPPORTED_BACKENDS[0], quiet=True):
         print()
         print(low_rank_solution)
         print()
-        print("Rank-{} approximation:".format(rank))
+        print(f"Rank-{rank} approximation:")
         print()
         print(low_rank_approximation)
         print()

--- a/examples/low_rank_psd_matrix_approximation.py
+++ b/examples/low_rank_psd_matrix_approximation.py
@@ -45,7 +45,7 @@ def create_cost_egrad_ehess(manifold, matrix, backend):
             X = tf.matmul(Y, tf.transpose(Y))
             return tf.norm(X - matrix) ** 2
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad, ehess
 

--- a/examples/multiple_linear_regression.py
+++ b/examples/multiple_linear_regression.py
@@ -46,7 +46,7 @@ def create_cost_egrad_ehess(manifold, samples, targets, backend):
             return tf.norm(
                 targets - tf.tensordot(samples, weights, axes=1)) ** 2
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad, ehess
 
@@ -68,7 +68,7 @@ def run(backend=SUPPORTED_BACKENDS[0], quiet=True):
 
         estimated_weights = solver.solve(problem)
         if not quiet:
-            print("Run {}".format(k+1))
+            print(f"Run {k + 1}")
             print("Weights found by pymanopt (top) / "
                   "closed form solution (bottom)")
             print(estimated_weights)

--- a/examples/notebooks/mixture_of_gaussians.ipynb
+++ b/examples/notebooks/mixture_of_gaussians.ipynb
@@ -181,11 +181,11 @@
    "outputs": [],
    "source": [
     "mu1hat = Xopt[0][0][0:2, 2:3]\n",
-    "Sigma1hat = Xopt[0][0][:2, :2] - mu1hat.dot(mu1hat.T)\n",
+    "Sigma1hat = Xopt[0][0][:2, :2] - mu1hat @ mu1hat.T\n",
     "mu2hat = Xopt[0][1][0:2, 2:3]\n",
-    "Sigma2hat = Xopt[0][1][:2, :2] - mu2hat.dot(mu2hat.T)\n",
+    "Sigma2hat = Xopt[0][1][:2, :2] - mu2hat @ mu2hat.T\n",
     "mu3hat = Xopt[0][2][0:2, 2:3]\n",
-    "Sigma3hat = Xopt[0][2][:2, :2] - mu3hat.dot(mu3hat.T)\n",
+    "Sigma3hat = Xopt[0][2][:2, :2] - mu3hat @ mu3hat.T\n",
     "pihat = np.exp(np.concatenate([Xopt[1], [0]], axis=0))\n",
     "pihat = pihat / np.sum(pihat)"
    ]

--- a/examples/notebooks/mixture_of_gaussians.py
+++ b/examples/notebooks/mixture_of_gaussians.py
@@ -159,11 +159,11 @@ Xopt = solver.solve(problem)
 # Once Pymanopt has finished the optimisation we can obtain the inferred parameters as follows:
 
 mu1hat = Xopt[0][0][0:2, 2:3]
-Sigma1hat = Xopt[0][0][:2, :2] - mu1hat.dot(mu1hat.T)
+Sigma1hat = Xopt[0][0][:2, :2] - mu1hat @ mu1hat.T
 mu2hat = Xopt[0][1][0:2, 2:3]
-Sigma2hat = Xopt[0][1][:2, :2] - mu2hat.dot(mu2hat.T)
+Sigma2hat = Xopt[0][1][:2, :2] - mu2hat @ mu2hat.T
 mu3hat = Xopt[0][2][0:2, 2:3]
-Sigma3hat = Xopt[0][2][:2, :2] - mu3hat.dot(mu3hat.T)
+Sigma3hat = Xopt[0][2][:2, :2] - mu3hat @ mu3hat.T
 pihat = np.exp(np.concatenate([Xopt[1], [0]], axis=0))
 pihat = pihat / np.sum(pihat)
 

--- a/examples/optimal_rotations.py
+++ b/examples/optimal_rotations.py
@@ -38,7 +38,7 @@ def create_cost_egrad(manifold, ABt, backend):
         def cost(X):
             return -tf.tensordot(X, ABt, axes=ABt.ndim)
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad
 

--- a/examples/packing_on_the_sphere.py
+++ b/examples/packing_on_the_sphere.py
@@ -44,7 +44,7 @@ def create_cost(manifold, epsilon, backend):
             u = tf.reduce_sum(tf.linalg.band_part(Y, 0, -1))
             return s + epsilon * tf.math.log(u)
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost
 

--- a/examples/pca.py
+++ b/examples/pca.py
@@ -55,7 +55,7 @@ def create_cost_egrad_ehess(manifold, samples, backend):
             projector = tf.matmul(w, tf.transpose(w))
             return tf.norm(samples - tf.matmul(samples, projector)) ** 2
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad, ehess
 

--- a/examples/rank_k_correlation_matrix_approximation.py
+++ b/examples/rank_k_correlation_matrix_approximation.py
@@ -44,7 +44,7 @@ def create_cost_egrad_ehess(manifold, matrix, backend):
         def cost(X):
             return 0.25 * tf.norm(tf.matmul(tf.transpose(X), X) - matrix) ** 2
     else:
-        raise ValueError("Unsupported backend '{:s}'".format(backend))
+        raise ValueError(f"Unsupported backend '{backend}'")
 
     return cost, egrad, ehess
 

--- a/pymanopt/autodiff/__init__.py
+++ b/pymanopt/autodiff/__init__.py
@@ -9,7 +9,7 @@ class Function:
         if not callable(function):
             raise TypeError(f"Object {function} is not callable")
         if not backend.is_available():
-            raise RuntimeError(f"Backend `{backend}' is not available")
+            raise RuntimeError(f"Backend '{backend}' is not available")
 
         self._function = function
         self._backend = backend
@@ -20,7 +20,7 @@ class Function:
         self._ehess = None
 
     def __str__(self):
-        return "Function <{}>".format(self._backend)
+        return f"Function <{self._backend}>"
 
     def compute_gradient(self):
         if self._egrad is None:

--- a/pymanopt/autodiff/backends/_backend.py
+++ b/pymanopt/autodiff/backends/_backend.py
@@ -30,8 +30,7 @@ class Backend(metaclass=abc.ABCMeta):
         @functools.wraps(method)
         def wrapper(self, *args, **kwargs):
             if not self.is_available():
-                raise RuntimeError(
-                    "Backend '{}' is not available".format(self))
+                raise RuntimeError(f"Backend '{self}' is not available")
             return method(self, *args, **kwargs)
         return wrapper
 

--- a/pymanopt/autodiff/backends/_callable.py
+++ b/pymanopt/autodiff/backends/_callable.py
@@ -16,8 +16,9 @@ class _CallableBackend(Backend):
 
     def _raise_not_implemented_error(self, *args, **kwargs):
         raise NotImplementedError(
-            "No autodiff support available for the canonical '{}' "
-            "backend".format(self))
+            f"No autodiff support available for the canonical '{self}' "
+            "backend"
+        )
 
     compute_gradient = _raise_not_implemented_error
     compute_hessian_vector_product = _raise_not_implemented_error

--- a/pymanopt/core/problem.py
+++ b/pymanopt/core/problem.py
@@ -85,16 +85,15 @@ class Problem:
                 raise ValueError(
                     "Verbosity level must be an nonnegative integer")
             if key in ("manifold", "precon"):
-                raise AttributeError(
-                    "Cannot override '{:s}' attribute".format(key))
+                raise AttributeError(f"Cannot override '{key}' attribute")
         super().__setattr__(key, value)
 
     @staticmethod
     def _validate_function(function, name):
         if function is not None and not isinstance(function, Function):
             raise ValueError(
-                "Function '{:s}' must be decorated with one of the decorators "
-                "from 'pymanopt.function'".format(name))
+                f"Function '{name}' must be decorated with a backend decorator"
+            )
 
     def _flatten_arguments(self, arguments, signature):
         assert len(arguments) == len(signature)

--- a/pymanopt/manifolds/complex_circle.py
+++ b/pymanopt/manifolds/complex_circle.py
@@ -23,7 +23,7 @@ class ComplexCircle(EuclideanEmbeddedSubmanifold):
         super().__init__(name, dimension)
 
     def inner(self, z, v, w):
-        return v.conj().dot(w).real
+        return (v.conj() @ w).real
 
     def norm(self, x, v):
         return la.norm(v)

--- a/pymanopt/manifolds/complex_circle.py
+++ b/pymanopt/manifolds/complex_circle.py
@@ -19,7 +19,7 @@ class ComplexCircle(EuclideanEmbeddedSubmanifold):
         if dimension == 1:
             name = "Complex circle S^1"
         else:
-            name = "Complex circle (S^1)^{:d}".format(dimension)
+            name = f"Product manifold of complex circles (S^1)^{dimension}"
         super().__init__(name, dimension)
 
     def inner(self, z, v, w):

--- a/pymanopt/manifolds/complex_grassmann.py
+++ b/pymanopt/manifolds/complex_grassmann.py
@@ -27,10 +27,9 @@ class ComplexGrassmann(Manifold):
             raise ValueError("Need k >= 1. Value supplied was k = %d." % k)
 
         if k == 1:
-            name = "Complex Grassmann manifold Gr({:d}, {:d})".format(n, p)
+            name = f"Complex Grassmann manifold Gr({n},{p})"
         elif k >= 2:
-            name = ("Product complex Grassmann manifold Gr({:d}, {:d})^{:d}"
-                    .format(n, p, k))
+            name = f"Product complex Grassmann manifold Gr({n},{p})^{k}"
         dimension = int(2 * k * (n * p - p ** 2))
         super().__init__(name, dimension)
 

--- a/pymanopt/manifolds/euclidean.py
+++ b/pymanopt/manifolds/euclidean.py
@@ -68,11 +68,13 @@ class Euclidean(_Euclidean):
         if len(shape) == 0:
             raise TypeError("Need shape parameters")
         if len(shape) == 1:
-            name = "Euclidean manifold of {}-vectors".format(*shape)
+            (n1,) = shape
+            name = f"Euclidean manifold of {n1}-vectors"
         elif len(shape) == 2:
-            name = ("Euclidean manifold of {}x{} matrices").format(*shape)
+            n1, n2 = shape
+            name = f"Euclidean manifold of {n1}x{n2} matrices"
         else:
-            name = ("Euclidean manifold of shape " + str(shape) + " tensors")
+            name = f"Euclidean manifold of shape {shape} tensors"
         dimension = np.prod(shape)
         super().__init__(name, dimension, *shape)
 
@@ -89,13 +91,12 @@ class Symmetric(_Euclidean):
     def __init__(self, n, k=1):
         if k == 1:
             shape = (n, n)
-            name = ("Manifold of {} x {} symmetric matrices").format(n, n)
+            name = f"Manifold of {n}x{n} symmetric matrices"
         elif k > 1:
             shape = (k, n, n)
-            name = ("Product manifold of {} ({} x {}) symmetric "
-                    "matrices").format(k, n, n)
+            name = f"Product manifold of {k} {n}x{n} symmetric matrices"
         else:
-            raise ValueError("k must be an integer no less than 1")
+            raise ValueError(f"k must be an integer no less than 1, got {k}")
         dimension = int(k * n * (n + 1) / 2)
         super().__init__(name, dimension, *shape)
 
@@ -123,12 +124,10 @@ class SkewSymmetric(_Euclidean):
     def __init__(self, n, k=1):
         if k == 1:
             shape = (n, n)
-            name = ("Manifold of {} x {} skew-symmetric "
-                    "matrices").format(n, n)
+            name = f"Manifold of {n}x{n} skew-symmetric matrices"
         elif k > 1:
             shape = (k, n, n)
-            name = ("Product manifold of {} ({} x {}) skew-symmetric "
-                    "matrices").format(k, n, n)
+            name = f"Product manifold of {k} {n}x{n} skew-symmetric matrices"
         else:
             raise ValueError("k must be an integer no less than 1")
         dimension = int(k * n * (n - 1) / 2)

--- a/pymanopt/manifolds/fixed_rank.py
+++ b/pymanopt/manifolds/fixed_rank.py
@@ -82,8 +82,7 @@ class FixedRankEmbedded(EuclideanEmbeddedSubmanifold):
         self._stiefel_m = Stiefel(m, k)
         self._stiefel_n = Stiefel(n, k)
 
-        name = ("Manifold of {m}-by-{n} matrices with rank {k} and embedded "
-                "geometry".format(m=m, n=n, k=k))
+        name = f"Embedded manifold of {m}x{n} matrices of rank {k}"
         dimension = (m + n - k) * k
         super().__init__(name, dimension, point_layout=3)
 

--- a/pymanopt/manifolds/grassmann.py
+++ b/pymanopt/manifolds/grassmann.py
@@ -28,10 +28,9 @@ class Grassmann(Manifold):
             raise ValueError("Need k >= 1. Value supplied was k = %d." % k)
 
         if k == 1:
-            name = "Grassmann manifold Gr({:d}, {:d})".format(n, p)
+            name = f"Grassmann manifold Gr({n},{p})"
         elif k >= 2:
-            name = "Product Grassmann manifold Gr({:d}, {:d})^{:d}".format(
-                n, p, k)
+            name = f"Product Grassmann manifold Gr({n},{p})^{k}"
         dimension = int(k * (n * p - p ** 2))
         super().__init__(name, dimension)
 

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -1,7 +1,21 @@
 import abc
 import functools
+import warnings
 
 import numpy as np
+
+
+class RetrAsExpMixin:
+    """Mixin which defers calls to the exponential map to the retraction."""
+
+    def exp(self, Y, U):
+        class_name = self.__class__.__name__
+        warnings.warn(
+            f"Exponential map for manifold '{class_name}' not available. "
+            "Using retraction instead.",
+            RuntimeWarning
+        )
+        return self.retr(Y, U)
 
 
 class Manifold(metaclass=abc.ABCMeta):

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -60,9 +60,6 @@ class Manifold(metaclass=abc.ABCMeta):
     def __str__(self):
         return self._name
 
-    def _get_class_name(self):
-        return self.__class__.__name__
-
     @property
     def dim(self):
         """The dimension of the manifold."""
@@ -96,7 +93,7 @@ class Manifold(metaclass=abc.ABCMeta):
         and maximal trust-region radii.
         """
         raise NotImplementedError(
-            f"Manifold '{self._get_class_name()}' does not provide a "
+            f"Manifold '{self.__class__.__name__}' does not provide a "
             "'typicaldist' property"
         )
 
@@ -136,7 +133,7 @@ class Manifold(metaclass=abc.ABCMeta):
         @functools.wraps(method)
         def wrapper(self, *args, **kwargs):
             raise NotImplementedError(
-                f"Manifold '{self._get_class_name()}' provides no "
+                f"Manifold '{self.__class__.__name__}' provides no "
                 f"implementation for '{method.__name__}'"
             )
         return wrapper

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -96,10 +96,11 @@ class Manifold(metaclass=abc.ABCMeta):
         and maximal trust-region radii.
         """
         raise NotImplementedError(
-            "Manifold class '{:s}' does not provide a 'typicaldist'".format(
-                self._get_class_name()))
+            f"Manifold '{self._get_class_name()}' does not provide a "
+            "'typicaldist' property"
+        )
 
-    # Abstract methods that subclasses must implement
+    # Abstract methods that subclasses must implement.
 
     @abc.abstractmethod
     def inner(self, X, G, H):
@@ -129,14 +130,15 @@ class Manifold(metaclass=abc.ABCMeta):
     def zerovec(self, X):
         """Returns the zero vector in the tangent space at ``X``."""
 
-    # Methods which are only required by certain solvers
+    # Methods which are only required by certain solvers.
 
     def _raise_not_implemented_error(method):
         @functools.wraps(method)
         def wrapper(self, *args, **kwargs):
             raise NotImplementedError(
-                "Manifold class '{:s}' provides no implementation for "
-                "'{:s}'".format(self._get_class_name(), method.__name__))
+                f"Manifold '{self._get_class_name()}' provides no "
+                f"implementation for '{method.__name__}'"
+            )
         return wrapper
 
     @_raise_not_implemented_error

--- a/pymanopt/manifolds/oblique.py
+++ b/pymanopt/manifolds/oblique.py
@@ -18,7 +18,7 @@ class Oblique(EuclideanEmbeddedSubmanifold):
     def __init__(self, m, n):
         self._m = m
         self._n = n
-        name = "Oblique manifold OB({:d}, {:d})".format(m, n)
+        name = f"Oblique manifold OB({m},{n})"
         dimension = (m - 1) * n
         super().__init__(name, dimension)
 

--- a/pymanopt/manifolds/product.py
+++ b/pymanopt/manifolds/product.py
@@ -14,8 +14,9 @@ class Product(Manifold):
             if isinstance(manifold, Product):
                 raise ValueError("Nested product manifolds are not supported")
         self._manifolds = tuple(manifolds)
-        name = ("Product manifold: {:s}".format(
-                " x ".join([str(man) for man in manifolds])))
+        manifold_names = " x ".join([str(man) for man in manifolds])
+        name = f"Product manifold: {manifold_names}"
+
         dimension = np.sum([man.dim for man in manifolds])
         point_layout = tuple(manifold.point_layout for manifold in manifolds)
         super().__init__(name, dimension, point_layout=point_layout)

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -3,11 +3,7 @@ import warnings
 import numpy as np
 from numpy import linalg as la, random as rnd
 from scipy.linalg import expm
-# Workaround for SciPy bug: https://github.com/scipy/scipy/pull/8082
-try:
-    from scipy.linalg import solve_continuous_lyapunov as lyap
-except ImportError:
-    from scipy.linalg import solve_lyapunov as lyap
+from scipy.linalg import solve_continuous_lyapunov as lyap
 
 from pymanopt.manifolds.manifold import EuclideanEmbeddedSubmanifold, Manifold
 from pymanopt.tools.multi import multilog, multiprod, multisym, multitransp

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -23,10 +23,11 @@ class SymmetricPositiveDefinite(EuclideanEmbeddedSubmanifold):
         self._k = k
 
         if k == 1:
-            name = ("Manifold of positive definite ({} x {}) matrices").format(
-                n, n)
+            name = f"Manifold of positive definite {n}x{n} matrices"
         else:
-            name = "Product manifold of {} ({} x {}) matrices".format(k, n, n)
+            name = (
+                f"Product manifold of {k} positive definite {n}x{n} matrices"
+            )
         dimension = int(k * n * (n + 1) / 2)
         super().__init__(name, dimension)
 
@@ -222,8 +223,7 @@ class PSDFixedRank(_PSDFixedRank):
     """
 
     def __init__(self, n, k):
-        name = ("YY' quotient manifold of {:d}x{:d} psd matrices of "
-                "rank {:d}".format(n, n, k))
+        name = f"Quotient manifold of {n}x{n} psd matrices of rank {k}"
         dimension = int(k * n - k * (k - 1) / 2)
         super().__init__(n, k, name, dimension)
 
@@ -254,8 +254,7 @@ class PSDFixedRankComplex(_PSDFixedRank):
     """
 
     def __init__(self, n, k):
-        name = ("YY' quotient manifold of Hermitian {:d}x{:d} complex "
-                "matrices of rank {:d}".format(n, n, k))
+        name = f"Quotient manifold of Hermitian {n}x{n} matrices of rank {k}"
         dimension = 2 * k * n - k * k
         super().__init__(n, k, name, dimension)
 
@@ -309,8 +308,8 @@ class Elliptope(Manifold, RetrAsExpMixin):
         self._n = n
         self._k = k
 
-        name = ("YY' quotient manifold of {:d}x{:d} psd matrices of rank {:d} "
-                "with diagonal elements being 1".format(n, n, k))
+        name = (f"Quotient manifold of {n}x{n} psd matrices of rank {k} "
+                "with unit diagonal elements")
         dimension = int(n * (k - 1) - k * (k - 1) / 2)
         super().__init__(name, dimension)
 

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -157,10 +157,10 @@ class _PSDFixedRank(Manifold, RetrAsExpMixin):
 
     def proj(self, Y, H):
         # Projection onto the horizontal space
-        YtY = Y.T.dot(Y)
-        AS = Y.T.dot(H) - H.T.dot(Y)
+        YtY = Y.T @ Y
+        AS = Y.T @ H - H.T @ Y
         Omega = lyap(YtY, AS)
-        return H - Y.dot(Omega)
+        return H - Y @ Omega
 
     def egrad2rgrad(self, Y, egrad):
         return egrad
@@ -266,8 +266,8 @@ class PSDFixedRankComplex(_PSDFixedRank):
         return np.sqrt(self.inner(Y, U, U))
 
     def dist(self, U, V):
-        S, _, D = la.svd(V.T.conj().dot(U))
-        E = U - V.dot(S).dot(D)
+        S, _, D = la.svd(V.T.conj() @ U)
+        E = U - V @ S @ D
         return self.inner(None, E, E) / 2
 
     def rand(self):
@@ -330,10 +330,10 @@ class Elliptope(Manifold, RetrAsExpMixin):
         eta = self._project_rows(Y, H)
 
         # Projection onto the horizontal space
-        YtY = Y.T.dot(Y)
-        AS = Y.T.dot(eta) - H.T.dot(Y)
+        YtY = Y.T @ Y
+        AS = Y.T @ eta - H.T @ Y
         Omega = lyap(YtY, -AS)
-        return eta - Y.dot((Omega - Omega.T) / 2)
+        return eta - Y @ (Omega - Omega.T) / 2
 
     def retr(self, Y, U):
         return self._normalize_rows(Y + U)

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -1,23 +1,14 @@
-import warnings
-
 import numpy as np
 from numpy import linalg as la, random as rnd
 from scipy.linalg import expm
 from scipy.linalg import solve_continuous_lyapunov as lyap
 
-from pymanopt.manifolds.manifold import EuclideanEmbeddedSubmanifold, Manifold
+from pymanopt.manifolds.manifold import (
+    EuclideanEmbeddedSubmanifold,
+    Manifold,
+    RetrAsExpMixin,
+)
 from pymanopt.tools.multi import multilog, multiprod, multisym, multitransp
-
-
-class _RetrAsExpMixin:
-    """Mixin to use a retraction as exponential map."""
-
-    def exp(self, Y, U):
-        warnings.warn(
-            "Exponential map for manifold '{:s}' not implemented yet. Using "
-            "retraction instead.".format(self._get_class_name()),
-            RuntimeWarning)
-        return self.retr(Y, U)
 
 
 class SymmetricPositiveDefinite(EuclideanEmbeddedSubmanifold):
@@ -147,7 +138,7 @@ class SymmetricPositiveDefinite(EuclideanEmbeddedSubmanifold):
 #              psd matrices, or in fixed_rank. Alternatively, move this one and
 #              the next class to a dedicated 'psd_fixed_rank' module.
 
-class _PSDFixedRank(Manifold, _RetrAsExpMixin):
+class _PSDFixedRank(Manifold, RetrAsExpMixin):
     def __init__(self, n, k, name, dimension):
         self._n = n
         self._k = k
@@ -284,7 +275,7 @@ class PSDFixedRankComplex(_PSDFixedRank):
         return rand_() + 1j * rand_()
 
 
-class Elliptope(Manifold, _RetrAsExpMixin):
+class Elliptope(Manifold, RetrAsExpMixin):
     """Manifold of fixed-rank PSD matrices with unit diagonal elements.
 
     A point X on the manifold is parameterized as YY^T where Y is a matrix of

--- a/pymanopt/manifolds/special_orthogonal_group.py
+++ b/pymanopt/manifolds/special_orthogonal_group.py
@@ -75,7 +75,7 @@ class SpecialOrthogonalGroup(EuclideanEmbeddedSubmanifold):
     def retr(self, X, U):
         def retri(Y):
             Q, R = la.qr(Y)
-            return np.dot(Q, np.diag(np.sign(np.sign(np.diag(R)) + 0.5)))
+            return Q @ np.diag(np.sign(np.sign(np.diag(R)) + 0.5))
 
         Y = X + multiprod(X, U)
         if self._k == 1:
@@ -88,7 +88,7 @@ class SpecialOrthogonalGroup(EuclideanEmbeddedSubmanifold):
     def retr2(self, X, U):
         def retr2i(Y):
             U, _, Vt = la.svd(Y)
-            return np.dot(U, Vt)
+            return U @ Vt
 
         Y = X + multiprod(X, U)
         if self._k == 1:
@@ -126,7 +126,8 @@ class SpecialOrthogonalGroup(EuclideanEmbeddedSubmanifold):
             # group of orthogonal n-by-n matrices.
             A = rnd.randn(n, n)
             Q, RR = la.qr(A)
-            Q = np.dot(Q, np.diag(np.sign(np.diag(RR))))  # Mezzadri 2007
+            # TODO(nkoep): Add a proper reference to Mezzadri 2007.
+            Q = Q @ np.diag(np.sign(np.diag(RR)))
 
             # If Q is in O(n) but not in SO(n), we permute the two first
             # columns of Q such that det(new Q) = -det(Q), hence the new Q will

--- a/pymanopt/manifolds/special_orthogonal_group.py
+++ b/pymanopt/manifolds/special_orthogonal_group.py
@@ -38,9 +38,9 @@ class SpecialOrthogonalGroup(EuclideanEmbeddedSubmanifold):
         self._k = k
 
         if k == 1:
-            name = "Rotations manifold SO({n})".format(n=n)
+            name = f"Special orthogonal group SO({n})"
         elif k > 1:
-            name = "Rotations manifold SO({n})^{k}".format(n=n, k=k)
+            name = f"Sphecial orthogonal group SO({n})^{k}"
         else:
             raise ValueError("k must be an integer no less than 1.")
         dimension = int(k * comb(n, 2))

--- a/pymanopt/manifolds/sphere.py
+++ b/pymanopt/manifolds/sphere.py
@@ -114,9 +114,9 @@ class _SphereSubspaceIntersectionManifold(_Sphere):
         assert m == n, "projection matrix is not square"
         if dimension == 0:
             warnings.warn(
-                "Intersected subspace is 1-dimensional! The manifold "
-                f"'{self._get_class_name()}' therefore has dimension 0 as it "
-                "only consists of isolated points"
+                "Intersected subspace is 1-dimensional. The manifold "
+                "therefore has dimension 0 as it only consists of isolated "
+                "points"
             )
         self._subspace_projector = projector
         super().__init__(n, name=name, dimension=dimension)

--- a/pymanopt/manifolds/sphere.py
+++ b/pymanopt/manifolds/sphere.py
@@ -128,15 +128,15 @@ class _SphereSubspaceIntersectionManifold(_Sphere):
 
     def proj(self, X, H):
         Y = super().proj(X, H)
-        return self._subspace_projector.dot(Y)
+        return self._subspace_projector @ Y
 
     def rand(self):
         X = super().rand()
-        return self._normalize(self._subspace_projector.dot(X))
+        return self._normalize(self._subspace_projector @ X)
 
     def randvec(self, X):
         Y = super().randvec(X)
-        return self._normalize(self._subspace_projector.dot(Y))
+        return self._normalize(self._subspace_projector @ Y)
 
 
 class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
@@ -151,7 +151,7 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
         self._validate_span_matrix(U)
         m = U.shape[0]
         Q, _ = la.qr(U)
-        projector = Q.dot(Q.T)
+        projector = Q @ Q.T
         subspace_dimension = la.matrix_rank(projector)
         name = ("Sphere manifold of {}-dimensional vectors intersecting a "
                 "{}-dimensional subspace".format(m, subspace_dimension))
@@ -172,7 +172,7 @@ class SphereSubspaceComplementIntersection(
         self._validate_span_matrix(U)
         m = U.shape[0]
         Q, _ = la.qr(U)
-        projector = np.eye(m) - Q.dot(Q.T)
+        projector = np.eye(m) - Q @ Q.T
         subspace_dimension = la.matrix_rank(projector)
         name = ("Sphere manifold of {}-dimensional vectors orthogonal "
                 "to a {}-dimensional subspace".format(m, subspace_dimension))

--- a/pymanopt/manifolds/sphere.py
+++ b/pymanopt/manifolds/sphere.py
@@ -97,11 +97,13 @@ class Sphere(_Sphere):
         if len(shape) == 0:
             raise TypeError("Need shape parameters.")
         if len(shape) == 1:
-            name = "Sphere manifold of {}-vectors".format(*shape)
+            (n1,) = shape
+            name = f"Sphere manifold of {n1}-vectors"
         elif len(shape) == 2:
-            name = "Sphere manifold of {}x{} matrices".format(*shape)
+            n1, n2 = shape
+            name = f"Sphere manifold of {n1}x{n2} matrices"
         else:
-            name = "Sphere manifold of shape " + str(shape) + " tensors"
+            name = f"Sphere manifold of shape {shape} tensors"
         dimension = np.prod(shape) - 1
         super().__init__(*shape, name=name, dimension=dimension)
 
@@ -112,9 +114,10 @@ class _SphereSubspaceIntersectionManifold(_Sphere):
         assert m == n, "projection matrix is not square"
         if dimension == 0:
             warnings.warn(
-                "Intersected subspace is 1-dimensional! The manifold '{:s}' "
-                "therefore has dimension 0 as it only consists of isolated "
-                "points".format(self._get_class_name()))
+                "Intersected subspace is 1-dimensional! The manifold "
+                f"'{self._get_class_name()}' therefore has dimension 0 as it "
+                "only consists of isolated points"
+            )
         self._subspace_projector = projector
         super().__init__(n, name=name, dimension=dimension)
 
@@ -153,8 +156,8 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
         Q, _ = la.qr(U)
         projector = Q @ Q.T
         subspace_dimension = la.matrix_rank(projector)
-        name = ("Sphere manifold of {}-dimensional vectors intersecting a "
-                "{}-dimensional subspace".format(m, subspace_dimension))
+        name = (f"Sphere manifold of {m}-dimensional vectors intersecting a "
+                f"{subspace_dimension}-dimensional subspace")
         dimension = subspace_dimension - 1
         super().__init__(projector, name, dimension)
 
@@ -174,7 +177,7 @@ class SphereSubspaceComplementIntersection(
         Q, _ = la.qr(U)
         projector = np.eye(m) - Q @ Q.T
         subspace_dimension = la.matrix_rank(projector)
-        name = ("Sphere manifold of {}-dimensional vectors orthogonal "
-                "to a {}-dimensional subspace".format(m, subspace_dimension))
+        name = (f"Sphere manifold of {m}-dimensional vectors orthogonal "
+                f"to a {subspace_dimension}-dimensional subspace")
         dimension = subspace_dimension - 1
         super().__init__(projector, name, dimension)

--- a/pymanopt/manifolds/stiefel.py
+++ b/pymanopt/manifolds/stiefel.py
@@ -58,13 +58,12 @@ class Stiefel(EuclideanEmbeddedSubmanifold):
             # Calculate 'thin' qr decomposition of X + G
             q, r = np.linalg.qr(X + G)
             # Unflip any flipped signs
-            XNew = np.dot(q, np.diag(np.sign(np.sign(np.diag(r)) + 0.5)))
+            XNew = q @ np.diag(np.sign(np.sign(np.diag(r)) + 0.5))
         else:
             XNew = X + G
             for i in range(self._k):
                 q, r = np.linalg.qr(XNew[i])
-                XNew[i] = np.dot(
-                    q, np.diag(np.sign(np.sign(np.diag(r)) + 0.5)))
+                XNew[i] = q @ np.diag(np.sign(np.sign(np.diag(r)) + 0.5))
         return XNew
 
     def norm(self, X, G):
@@ -95,20 +94,19 @@ class Stiefel(EuclideanEmbeddedSubmanifold):
         return self.proj(x2, d)
 
     def exp(self, X, U):
-        # TODO: Simplify these expressions.
         if self._k == 1:
-            W = expm(np.bmat([[X.T.dot(U), -U.T.dot(U)],
-                              [np.eye(self._p), X.T.dot(U)]]))
-            Z = np.bmat([[expm(-X.T.dot(U))], [np.zeros((self._p, self._p))]])
-            Y = np.bmat([X, U]).dot(W).dot(Z)
+            W = expm(np.bmat([[X.T @ U, -U.T @ U],
+                              [np.eye(self._p), X.T @ U]]))
+            Z = np.bmat([[expm(-X.T @ U)], [np.zeros((self._p, self._p))]])
+            Y = np.bmat([X, U]) @ W @ Z
         else:
             Y = np.zeros(np.shape(X))
             for i in range(self._k):
-                W = expm(np.bmat([[X[i].T.dot(U[i]), -U[i].T.dot(U[i])],
-                                  [np.eye(self._p), X[i].T.dot(U[i])]]))
-                Z = np.bmat([[expm(-X[i].T.dot(U[i]))],
+                W = expm(np.bmat([[X[i].T @ U[i], -U[i].T @ U[i]],
+                                  [np.eye(self._p), X[i].T @ U[i]]]))
+                Z = np.bmat([[expm(-X[i].T @ U[i])],
                              [np.zeros((self._p, self._p))]])
-                Y[i] = np.bmat([X[i], U[i]]).dot(W).dot(Z)
+                Y[i] = np.bmat([X[i], U[i]]) @ W @ Z
         return Y
 
     def zerovec(self, X):

--- a/pymanopt/manifolds/strictly_positive_vectors.py
+++ b/pymanopt/manifolds/strictly_positive_vectors.py
@@ -16,11 +16,9 @@ class StrictlyPositiveVectors(EuclideanEmbeddedSubmanifold):
         self._k = k
 
         if k == 1:
-            name = ("Manifold of strictly positive vectors of size {}").format(
-                n)
+            name = f"Manifold of strictly positive {n}-vectors"
         else:
-            name = ("Product manifold of {} \
-                    strictly positive vectors of size {}").format(k, n)
+            name = f"Product manifold of {k} strictly positive {n}-vectors"
         dimension = int(k * n)
         super().__init__(name, dimension)
 

--- a/pymanopt/solvers/trust_regions.py
+++ b/pymanopt/solvers/trust_regions.py
@@ -140,8 +140,7 @@ class TrustRegions(Solver):
         if verbosity >= 1:
             print("Optimizing...")
         if verbosity >= 2:
-            print("{:44s}f: {:+.6e}   |grad|: {:.6e}".format(
-                " ", float(fx), norm_grad))
+            print(f"{' ':44s}f: {fx:+.6e}   |grad|: {norm_grad:.6e}")
 
         self._start_optlog()
 
@@ -304,8 +303,8 @@ class TrustRegions(Solver):
                           "decreases).")
                     print(" +++ Consider decreasing options.Delta_bar "
                           "by an order of magnitude.")
-                    print(" +++ Current values: Delta_bar = {:g} and "
-                          "Delta0 = {:g}".format(Delta_bar, Delta0))
+                    print(f" +++ Current values: Delta_bar = {Delta_bar:g} "
+                          f"and Delta0 = {Delta0:g}")
             # If the actual decrease is at least 3/4 of the precicted decrease
             # and the tCG (inner solve) hit the TR boundary, increase the TR
             # radius. We also keep track of the number of consecutive
@@ -323,8 +322,8 @@ class TrustRegions(Solver):
                           "increases).")
                     print(" +++ Consider increasing options.Delta_bar "
                           "by an order of magnitude.")
-                    print(" +++ Current values: Delta_bar = {:g} and "
-                          "Delta0 = {:g}.".format(Delta_bar, Delta0))
+                    print(f" +++ Current values: Delta_bar = {Delta_bar:g} "
+                          f"and Delta0 = {Delta0:g}.")
             else:
                 # Otherwise, keep the TR radius constant.
                 consecutive_TRplus = 0
@@ -348,18 +347,16 @@ class TrustRegions(Solver):
 
             # ** Display:
             if verbosity == 2:
-                print("{:.3s} {:.3s}   k: {:5d}     num_inner: "
-                      "{:5d}     f: {:+e}   |grad|: {:e}   "
-                      "{:s}".format(accstr, trstr, k, numit,
-                                    float(fx), norm_grad, srstr))
+                print(f"{accstr:.3s} {trstr:.3s}   k: {k:5d}     num_inner: "
+                      f"{numit:5d}     f: {fx:+e}   |grad|: "
+                      f"{norm_grad:e}   {srstr:s}")
             elif verbosity > 2:
                 if self.use_rand and used_cauchy:
                     print("USED CAUCHY POINT")
-                print("{:.3s} {:.3s}    k: {:5d}     num_inner: "
-                      "{:5d}     {:s}".format(accstr, trstr, k, numit, srstr))
-                print("       f(x) : {:+e}     |grad| : "
-                      "{:e}".format(fx, norm_grad))
-                print("        rho : {:e}".format(rho))
+                print(f"{accstr:.3s} {trstr:.3s}    k: {k:5d}     num_inner: "
+                      f"{numit:5d}     {srstr:s}")
+                print(f"       f(x) : {fx:+e}     |grad| : {norm_grad:e}")
+                print(f"        rho : {rho:e}")
 
             # ** CHECK STOPPING criteria
             stop_reason = self._check_stopping_criterion(

--- a/pymanopt/tools/diagnostics.py
+++ b/pymanopt/tools/diagnostics.py
@@ -148,8 +148,7 @@ def check_gradient(problem, x=None, d=None):
         projected_grad = problem.manifold.tangent(x, grad)
         residual = grad - projected_grad
         err = problem.manifold.norm(x, residual)
-        print("The residual should be 0, or very close. "
-              "Residual: {:g}.".format(err))
+        print(f"The residual should be 0, or very close. Residual: {err:g}.")
         print("If it is far from 0, then the gradient "
               "is not in the tangent space.")
     else:

--- a/pymanopt/tools/multi.py
+++ b/pymanopt/tools/multi.py
@@ -21,7 +21,7 @@ def multiprod(A: np.ndarray, B: np.ndarray) -> np.ndarray:
         ``B`` (if ``A.ndim == 2``).
     """
     if A.ndim == 2:
-        return np.dot(A, B)
+        return A @ B
     return np.einsum("ijk,ikl->ijl", A, B)
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 autograd>=1.2
 numpy>=1.16
-scipy
+scipy>=1.0
 tensorflow>=2.0
 torch>=1.0

--- a/tests/test_backends/_backend_tests.py
+++ b/tests/test_backends/_backend_tests.py
@@ -87,7 +87,7 @@ class TestNaryFunction(unittest.TestCase):
         x = rnd.randn(n)
         y = rnd.randn(n)
 
-        self.assertAlmostEqual(np.dot(x, y), cost(x, y))
+        self.assertAlmostEqual(x @ y, cost(x, y))
 
         egrad = cost.compute_gradient()
         g = egrad(x, y)
@@ -197,10 +197,10 @@ class TestVector(unittest.TestCase):
 
         diag = np.eye(n)
 
-        H = np.exp(np.sum(Y ** 2)) * (4 * Ymat.T.dot(Ymat) + 2 * diag)
+        H = np.exp(np.sum(Y ** 2)) * (4 * Ymat.T @ Ymat + 2 * diag)
 
         # Then 'left multiply' H by A
-        self.correct_hess = np.squeeze(np.array(Amat.dot(H)))
+        self.correct_hess = np.squeeze(np.array(Amat @ H))
 
     def test_compile(self):
         np_testing.assert_allclose(self.correct_cost, self.cost(self.Y))
@@ -343,10 +343,10 @@ class TestMixed(unittest.TestCase):
 
         diag = np.eye(n1)
 
-        H = np.exp(np.sum(y[0] ** 2)) * (4 * Ymat.T.dot(Ymat) + 2 * diag)
+        H = np.exp(np.sum(y[0] ** 2)) * (4 * Ymat.T @ Ymat + 2 * diag)
 
         # Then 'left multiply' H by A
-        h1 = np.array(Amat.dot(H)).flatten()
+        h1 = np.array(Amat @ H).flatten()
 
         # 2. MATRIX
         # First form hessian tensor H (4th order)

--- a/tests/test_manifolds/test_complex_grassmann.py
+++ b/tests/test_manifolds/test_complex_grassmann.py
@@ -14,7 +14,7 @@ class TestSingleComplexGrassmannManifold(TestCase):
         self.k = k = 1
         self.man = ComplexGrassmann(m, n, k=k)
 
-        self.proj = lambda x, u: u - np.dot(x, np.dot(x.T, u))
+        self.proj = lambda x, u: u - x @ x.T @ u
 
     def test_inner(self):
         X = self.man.rand()

--- a/tests/test_manifolds/test_fixed_rank.py
+++ b/tests/test_manifolds/test_fixed_rank.py
@@ -32,8 +32,8 @@ class TestFixedRankEmbeddedManifold(TestCase):
         a = e.randvec(x)
         b = e.randvec(x)
         # First embed in the ambient space
-        A = x[0].dot(a[1].dot(x[2])) + a[0].dot(x[2]) + x[0].dot(a[2].T)
-        B = x[0].dot(b[1].dot(x[2])) + b[0].dot(x[2]) + x[0].dot(b[2].T)
+        A = x[0] @ a[1] @ x[2] + a[0] @ x[2] + x[0] @ a[2].T
+        B = x[0] @ b[1] @ x[2] + b[0] @ x[2] + x[0] @ b[2].T
         trueinner = np.sum(A*B)
         np_testing.assert_almost_equal(trueinner, e.inner(x, a, b))
 
@@ -44,10 +44,10 @@ class TestFixedRankEmbeddedManifold(TestCase):
 
         g = m.proj(x, v)
         # Check that g is a true tangent vector
-        np_testing.assert_allclose(np.dot(g[0].T, x[0]),
+        np_testing.assert_allclose(g[0].T @ x[0],
                                    np.zeros((self.k, self.k)),
                                    atol=1e-6)
-        np_testing.assert_allclose(np.dot(g[2].T, x[2].T),
+        np_testing.assert_allclose(g[2].T @ x[2].T,
                                    np.zeros((self.k, self.k)),
                                    atol=1e-6)
 
@@ -66,8 +66,8 @@ class TestFixedRankEmbeddedManifold(TestCase):
         # Return to the ambient representation
         g = m.tangent2ambient(x, g)
         g_disp = m.tangent2ambient(x, g_disp)
-        g = g[0].dot(g[1]).dot(g[2].T)
-        g_disp = g_disp[0].dot(g_disp[1]).dot(g_disp[2].T)
+        g = g[0] @ g[1] @ g[2].T
+        g_disp = g_disp[0] @ g_disp[1] @ g_disp[2].T
 
         assert np.linalg.norm(g - v) < np.linalg.norm(g_disp - v)
 
@@ -96,8 +96,8 @@ class TestFixedRankEmbeddedManifold(TestCase):
         assert np.shape(x[0]) == (self.m, self.k)
         assert np.shape(x[1]) == (self.k,)
         assert np.shape(x[2]) == (self.k, self.n)
-        np_testing.assert_allclose(x[0].T.dot(x[0]), np.eye(self.k), atol=1e-6)
-        np_testing.assert_allclose(x[2].dot(x[2].T), np.eye(self.k), atol=1e-6)
+        np_testing.assert_allclose(x[0].T @ x[0], np.eye(self.k), atol=1e-6)
+        np_testing.assert_allclose(x[2] @ x[2].T, np.eye(self.k), atol=1e-6)
 
         assert la.norm(x[0] - y[0]) > 1e-6
         assert la.norm(x[1] - y[1]) > 1e-6
@@ -117,30 +117,30 @@ class TestFixedRankEmbeddedManifold(TestCase):
         m = self.man
         z = np.random.randn(self.m, self.n)
 
-        # Set u, s, v so that z = u.dot(s).dot(v.T)
+        # Set u, s, v so that z = u @ s @ v.T
         u, s, v = np.linalg.svd(z, full_matrices=False)
         s = np.diag(s)
         v = v.T
 
         w = np.random.randn(self.n, self.n)
 
-        np_testing.assert_allclose(z.dot(w), m._apply_ambient(z, w))
-        np_testing.assert_allclose(z.dot(w), m._apply_ambient((u, s, v), w))
+        np_testing.assert_allclose(z @ w, m._apply_ambient(z, w))
+        np_testing.assert_allclose(z @ w, m._apply_ambient((u, s, v), w))
 
     def test_apply_ambient_transpose(self):
         m = self.man
         z = np.random.randn(self.n, self.m)
 
-        # Set u, s, v so that z = u.dot(s).dot(v.T)
+        # Set u, s, v so that z = u @ s @ v.T
         u, s, v = np.linalg.svd(z, full_matrices=False)
         s = np.diag(s)
         v = v.T
 
         w = np.random.randn(self.n, self.n)
 
-        np_testing.assert_allclose(z.T.dot(w),
+        np_testing.assert_allclose(z.T @ w,
                                    m._apply_ambient_transpose(z, w))
-        np_testing.assert_allclose(z.T.dot(w),
+        np_testing.assert_allclose(z.T @ w,
                                    m._apply_ambient_transpose((u, s, v), w))
 
     def test_tangent2ambient(self):
@@ -148,12 +148,11 @@ class TestFixedRankEmbeddedManifold(TestCase):
         x = m.rand()
         z = m.randvec(x)
 
-        z_ambient = (x[0].dot(z[1]).dot(x[2]) + z[0].dot(x[2]) +
-                     x[0].dot(z[2].T))
+        z_ambient = x[0] @ z[1] @ x[2] + z[0] @ x[2] + x[0] @ z[2].T
 
         u, s, v = m.tangent2ambient(x, z)
 
-        np_testing.assert_allclose(z_ambient, u.dot(s).dot(v.T))
+        np_testing.assert_allclose(z_ambient, u @ s @ v.T)
 
     def test_ehess2rhess(self):
         pass
@@ -166,16 +165,16 @@ class TestFixedRankEmbeddedManifold(TestCase):
 
         y = self.man.retr(x, u)
 
-        np_testing.assert_allclose(y[0].T.dot(y[0]), np.eye(self.k), atol=1e-6)
-        np_testing.assert_allclose(y[2].dot(y[2].T), np.eye(self.k), atol=1e-6)
+        np_testing.assert_allclose(y[0].T @ y[0], np.eye(self.k), atol=1e-6)
+        np_testing.assert_allclose(y[2] @ y[2].T, np.eye(self.k), atol=1e-6)
 
         u = u * 1e-6
         y = self.man.retr(x, u)
-        y = y[0].dot(np.diag(y[1])).dot(y[2])
+        y = y[0] @ np.diag(y[1]) @ y[2]
 
         u = self.man.tangent2ambient(x, u)
-        u = u[0].dot(u[1]).dot(u[2].T)
-        x = x[0].dot(np.diag(x[1])).dot(x[2])
+        u = u[0] @ u[1] @ u[2].T
+        x = x[0] @ np.diag(x[1]) @ x[2]
 
         np_testing.assert_allclose(y, x + u, atol=1e-5)
 
@@ -193,13 +192,13 @@ class TestFixedRankEmbeddedManifold(TestCase):
         ds = np.random.randn(self.k)
         dvt = np.random.randn(self.k, self.n)
 
-        Up = (np.dot(np.dot(np.eye(self.m) - np.dot(u, u.T), du),
-                     np.linalg.inv(np.diag(s))))
-        M = (np.dot(f * (np.dot(u.T, du) - np.dot(du.T, u)), np.diag(s)) +
-             np.dot(np.diag(s), f * (np.dot(vt, dvt.T) - np.dot(dvt, vt.T))) +
-             np.diag(ds))
-        Vp = (np.dot(np.dot(np.eye(self.n) - np.dot(vt.T, vt), dvt.T),
-                     np.linalg.inv(np.diag(s))))
+        Up = (np.eye(self.m) - u @ u.T) @ du @ np.linalg.inv(np.diag(s))
+        M = (
+            f * (u.T @ du - du.T @ u) @ np.diag(s)
+            + np.diag(s) @ f * (vt @ dvt.T - dvt @ vt.T)
+            + np.diag(ds)
+        )
+        Vp = (np.eye(self.n) - vt.T @ vt) @ dvt.T @ np.linalg.inv(np.diag(s))
 
         up, m, vp = m.egrad2rgrad(x, (du, ds, dvt))
 
@@ -216,10 +215,10 @@ class TestFixedRankEmbeddedManifold(TestCase):
         assert np.shape(u[0]) == (self.m, self.k)
         assert np.shape(u[1]) == (self.k, self.k)
         assert np.shape(u[2]) == (self.n, self.k)
-        np_testing.assert_allclose(np.dot(u[0].T, x[0]),
+        np_testing.assert_allclose(u[0].T @ x[0],
                                    np.zeros((self.k, self.k)),
                                    atol=1e-6)
-        np_testing.assert_allclose(np.dot(u[2].T, x[2].T),
+        np_testing.assert_allclose(u[2].T @ x[2].T,
                                    np.zeros((self.k, self.k)),
                                    atol=1e-6)
 

--- a/tests/test_manifolds/test_grassmann.py
+++ b/tests/test_manifolds/test_grassmann.py
@@ -14,7 +14,7 @@ class TestSingleGrassmannManifold(TestCase):
         self.k = k = 1
         self.man = Grassmann(m, n, k=k)
 
-        self.proj = lambda x, u: u - np.dot(x, np.dot(x.T, u))
+        self.proj = lambda x, u: u - x @ x.T @ u
 
     def test_dist(self):
         x = self.man.rand()
@@ -99,7 +99,7 @@ class TestMultiGrassmannManifold(TestCase):
         self.k = k = 3
         self.man = Grassmann(m, n, k=k)
 
-        self.proj = lambda x, u: u - np.dot(x, np.dot(x.T, u))
+        self.proj = lambda x, u: u - x @ x.T @ u
 
     def test_dim(self):
         assert self.man.dim == self.k * (self.m * self.n - self.n ** 2)

--- a/tests/test_manifolds/test_sphere.py
+++ b/tests/test_manifolds/test_sphere.py
@@ -47,7 +47,7 @@ class TestSphereManifold(TestCase):
         H = rnd.randn(self.m, self.n)
 
         #  Compare the projections.
-        np_testing.assert_array_almost_equal(H - X * np.trace(X.T.dot(H)),
+        np_testing.assert_array_almost_equal(H - X * np.trace(X.T @ H),
                                              self.man.proj(X, H))
 
     def test_egrad2rgrad(self):
@@ -60,7 +60,7 @@ class TestSphereManifold(TestCase):
         H = rnd.randn(self.m, self.n)
 
         #  Compare the projections.
-        np_testing.assert_array_almost_equal(H - X * np.trace(X.T.dot(H)),
+        np_testing.assert_array_almost_equal(H - X * np.trace(X.T @ H),
                                              self.man.egrad2rgrad(X, H))
 
     def test_ehess2rhess(self):
@@ -242,4 +242,4 @@ class TestSphereSubspaceComplementIntersectionManifold(TestCase):
         # Test if a random element really lies in the left null space of U.
         x = man.rand()
         np_testing.assert_almost_equal(la.norm(x), 1)
-        np_testing.assert_array_almost_equal(U.T.dot(x), np.zeros(U.shape[1]))
+        np_testing.assert_array_almost_equal(U.T @ x, np.zeros(U.shape[1]))

--- a/tests/test_manifolds/test_stiefel.py
+++ b/tests/test_manifolds/test_stiefel.py
@@ -13,8 +13,7 @@ class TestSingleStiefelManifold(TestCase):
         self.n = n = 2
         self.k = k = 1
         self.man = Stiefel(m, n, k=k)
-        self.proj = lambda x, u: u - np.dot(x, np.dot(x.T, u) +
-                                            np.dot(u.T, x)) / 2
+        self.proj = lambda x, u: u - x @ (x.T @ u + u.T @ x) / 2
 
     def test_dim(self):
         assert self.man.dim == 0.5 * self.n * (2 * self.m - self.n - 1)
@@ -37,14 +36,14 @@ class TestSingleStiefelManifold(TestCase):
         H = rnd.randn(self.m, self.n)
 
         # Compare the projections.
-        Hproj = H - X.dot(X.T.dot(H) + H.T.dot(X)) / 2
+        Hproj = H - X @ (X.T @ H + H.T @ X) / 2
         np_testing.assert_allclose(Hproj, self.man.proj(X, H))
 
     def test_rand(self):
         # Just make sure that things generated are on the manifold and that
         # if you generate two they are not equal.
         X = self.man.rand()
-        np_testing.assert_allclose(X.T.dot(X), np.eye(self.n), atol=1e-10)
+        np_testing.assert_allclose(X.T @ X, np.eye(self.n), atol=1e-10)
         Y = self.man.rand()
         assert np.linalg.norm(X - Y) > 1e-6
 
@@ -53,7 +52,7 @@ class TestSingleStiefelManifold(TestCase):
         # two then they are not equal.
         X = self.man.rand()
         U = self.man.randvec(X)
-        np_testing.assert_allclose(multisym(X.T.dot(U)),
+        np_testing.assert_allclose(multisym(X.T @ U),
                                    np.zeros((self.n, self.n)), atol=1e-10)
         V = self.man.randvec(X)
         assert la.norm(U - V) > 1e-6
@@ -65,8 +64,7 @@ class TestSingleStiefelManifold(TestCase):
         u = self.man.randvec(x)
 
         xretru = self.man.retr(x, u)
-        np_testing.assert_allclose(xretru.T.dot(xretru), np.eye(self.n,
-                                                                self.n),
+        np_testing.assert_allclose(xretru.T @ xretru, np.eye(self.n, self.n),
                                    atol=1e-10)
 
         u = u * 1e-6
@@ -101,8 +99,7 @@ class TestSingleStiefelManifold(TestCase):
         u = s.randvec(x)
 
         xexpu = s.exp(x, u)
-        np_testing.assert_allclose(xexpu.T.dot(xexpu), np.eye(self.n,
-                                                              self.n),
+        np_testing.assert_allclose(xexpu.T @ xexpu, np.eye(self.n, self.n),
                                    atol=1e-10)
 
         u = u * 1e-6

--- a/tests/test_multi_tools.py
+++ b/tests/test_multi_tools.py
@@ -20,7 +20,7 @@ class TestMulti(TestCase):
         B = rnd.randn(self.n, self.p)
 
         # Compare the products.
-        np_testing.assert_allclose(A.dot(B), multiprod(A, B))
+        np_testing.assert_allclose(A @ B, multiprod(A, B))
 
     def test_multiprod(self):
         # Two random arrays of matrices A (k x m x n) and B (k x n x p)
@@ -29,7 +29,7 @@ class TestMulti(TestCase):
 
         C = np.zeros((self.k, self.m, self.p))
         for i in range(self.k):
-            C[i] = A[i].dot(B[i])
+            C[i] = A[i] @ B[i]
 
         np_testing.assert_allclose(C, multiprod(A, B))
 
@@ -66,7 +66,7 @@ class TestMulti(TestCase):
         a = np.diag(rnd.rand(self.m))
         q, r = la.qr(rnd.randn(self.m, self.m))
         # A is a positive definite matrix
-        A = q.dot(a.dot(q.T))
+        A = q @ a @ q.T
         np_testing.assert_allclose(multilog(A, pos_def=True), logm(A))
 
     def test_multilog(self):
@@ -75,7 +75,7 @@ class TestMulti(TestCase):
         for i in range(self.k):
             a = np.diag(rnd.rand(self.m))
             q, r = la.qr(rnd.randn(self.m, self.m))
-            A[i] = q.dot(a.dot(q.T))
+            A[i] = q @ a @ q.T
             L[i] = logm(A[i])
         np_testing.assert_allclose(multilog(A, pos_def=True), L)
 


### PR DESCRIPTION
This PR is mostly cosmetic. It moves pymanopt's codebase to the f-string age and replaces all `np.dot` calls with python/numpy's matrix multiplication operator `@`.