### PR TITLE
Fix strictly positive vectors manifold

### DIFF
--- a/pymanopt/manifolds/strictly_positive_vectors.py
+++ b/pymanopt/manifolds/strictly_positive_vectors.py
@@ -68,8 +68,8 @@ class StrictlyPositiveVectors(EuclideanEmbeddedSubmanifold):
     def egrad2rgrad(self, x, u):
         return u * (x ** 2)
 
-    def ehess2rhess(self, x, egrad, ehess, u):
-        return ehess * (x ** 2) + egrad * u * x
+    def ehess2rhess(self, X, G, H, U):
+        return H * (X ** 2) + G * U * X
 
     def exp(self, x, u):
         return x * np.exp((1.0 / x) * u)
@@ -81,5 +81,5 @@ class StrictlyPositiveVectors(EuclideanEmbeddedSubmanifold):
     def log(self, x, y):
         return x * np.log((1.0 / x) * y)
 
-    def transp(self, x1, x2, d):
-        return self.proj(x2, x2 * (x1 ** -1) * d)
+    def transp(self, X1, X2, G):
+        return self.proj(X2, X2 * (X1 ** -1) * G)

--- a/tests/test_manifolds/test_strictly_positive_vectors.py
+++ b/tests/test_manifolds/test_strictly_positive_vectors.py
@@ -60,10 +60,7 @@ class TestSingleStrictlyPositiveVectors(TestCase):
 
     def test_zerovec(self):
         x = self.man.rand()
-        np_testing.assert_allclose(
-            self.man.zerovec(x),
-            np.zeros((self.n, 1))
-        )
+        np_testing.assert_allclose(self.man.zerovec(x), np.zeros((self.n, 1)))
 
     def test_dist(self):
         # To implement norm of log(x, y)
@@ -71,8 +68,7 @@ class TestSingleStrictlyPositiveVectors(TestCase):
         y = self.man.rand()
         u = self.man.log(x, y)
         assert type(self.man.dist(x, y)) is np.float64
-        np_testing.assert_allclose(self.man.norm(x, u),
-                                   self.man.dist(x, y))
+        np_testing.assert_allclose(self.man.norm(x, u), self.man.dist(x, y))
 
     def test_ehess2rhess(self):
         n = self.n
@@ -123,7 +119,7 @@ class TestSingleStrictlyPositiveVectors(TestCase):
         np_testing.assert_allclose(t_u, m.proj(y, t_u))
 
 
-class TestProductStrictlyPositiveVectors():
+class TestProductStrictlyPositiveVectors:
     def __init__(self):
         self.n = n = 10
         self.k = k = 2
@@ -175,8 +171,7 @@ class TestProductStrictlyPositiveVectors():
     def test_zerovec(self):
         x = self.man.rand()
         np_testing.assert_allclose(
-            self.man.zerovec(x),
-            np.zeros((self.k, self.n, 1))
+            self.man.zerovec(x), np.zeros((self.k, self.n, 1))
         )
 
     def test_dist(self):
@@ -185,8 +180,7 @@ class TestProductStrictlyPositiveVectors():
         y = self.man.rand()
         u = self.man.log(x, y)
         assert type(self.man.dist(x, y)) is np.float64
-        np_testing.assert_allclose(self.man.norm(x, u),
-                                   self.man.dist(x, y))
+        np_testing.assert_allclose(self.man.norm(x, u), self.man.dist(x, y))
 
     def test_ehess2rhess(self):
         k, n = self.k, self.n

--- a/tests/test_manifolds/test_strictly_positive_vectors.py
+++ b/tests/test_manifolds/test_strictly_positive_vectors.py
@@ -1,4 +1,4 @@
-import autograd.numpy as np
+import numpy as np
 from numpy import linalg as la
 from numpy import random as rnd
 from numpy import testing as np_testing
@@ -9,17 +9,17 @@ from pymanopt.manifolds import StrictlyPositiveVectors
 from .._test import TestCase
 
 
-class TestStrictlyPositiveVectors(TestCase):
+class TestSingleStrictlyPositiveVectors(TestCase):
     def setUp(self):
-        self.n = n = 3
-        self.k = k = 2
+        self.n = n = 10
+        self.k = k = 1
         self.man = StrictlyPositiveVectors(n, k=k)
 
     def test_inner(self):
         x = self.man.rand()
-        g = self.man.randvec(x)
-        h = self.man.randvec(x)
-        assert (self.man.inner(x, g, h).shape == np.array([1, self.k])).all()
+        g = 2 * self.man.randvec(x)
+        h = 3 * self.man.randvec(x)
+        assert type(self.man.inner(x, g, h)) is np.float64
 
     def test_proj(self):
         # Test proj(proj(X)) == proj(X)
@@ -34,14 +34,15 @@ class TestStrictlyPositiveVectors(TestCase):
         x = self.man.rand()
         u = self.man.randvec(x)
         x_u = (1.0 / x) * u
-        np_testing.assert_almost_equal(
-            la.norm(x_u, axis=0, keepdims=True), self.man.norm(x, u)
-        )
+        assert type(self.man.norm(x, u)) is np.float64
+        np_testing.assert_allclose(la.norm(x_u), self.man.norm(x, u))
 
     def test_rand(self):
         # Just make sure that things generated are on the manifold
         # and that if you generate two they are not equal.
+        n = self.n
         x = self.man.rand()
+        assert x.shape == (n, 1)
         assert (x > 0).all()
         y = self.man.rand()
         assert (self.man.dist(x, y)).all() > 1e-6
@@ -49,36 +50,54 @@ class TestStrictlyPositiveVectors(TestCase):
     def test_randvec(self):
         # Just make sure that if you generate two they are not equal.
         # check also if unit norm
+        n = self.n
         x = self.man.rand()
         g = self.man.randvec(x)
+        assert g.shape == (n, 1)
         h = self.man.randvec(x)
         assert (la.norm(g - h, axis=0) > 1e-6).all()
-        np_testing.assert_almost_equal(self.man.norm(x, g), 1)
+        np_testing.assert_allclose(self.man.norm(x, g), 1)
+
+    def test_zerovec(self):
+        x = self.man.rand()
+        np_testing.assert_allclose(
+            self.man.zerovec(x),
+            np.zeros((self.n, 1))
+        )
 
     def test_dist(self):
         # To implement norm of log(x, y)
         x = self.man.rand()
         y = self.man.rand()
         u = self.man.log(x, y)
-        np_testing.assert_almost_equal(
-            self.man.norm(x, u), self.man.dist(x, y)
-        )
+        assert type(self.man.dist(x, y)) is np.float64
+        np_testing.assert_allclose(self.man.norm(x, u),
+                                   self.man.dist(x, y))
 
-    # def test_ehess2rhess(self):
+    def test_ehess2rhess(self):
+        n = self.n
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        egrad = rnd.normal(size=(n, 1))
+        ehess = rnd.normal(size=(n, 1))
+        hess = self.man.ehess2rhess(x, egrad, ehess, u)
+        hess_proj = self.man.proj(x, hess)
+
+        np_testing.assert_allclose(hess, hess_proj)
 
     def test_exp_log_inverse(self):
         x = self.man.rand()
         y = self.man.rand()
         u = self.man.log(x, y)
         z = self.man.exp(x, u)
-        np_testing.assert_almost_equal(self.man.dist(y, z), 0)
+        np_testing.assert_allclose(self.man.dist(y, z), 0, atol=1e-10)
 
     def test_log_exp_inverse(self):
         x = self.man.rand()
         u = self.man.randvec(x)
         y = self.man.exp(x, u)
         v = self.man.log(x, y)
-        np_testing.assert_almost_equal(self.man.norm(x, u - v), 0)
+        np_testing.assert_allclose(self.man.norm(x, u - v), 0, atol=1e-10)
 
     def test_retr(self):
         # Test that the result is on the manifold and that for small
@@ -94,4 +113,125 @@ class TestStrictlyPositiveVectors(TestCase):
         xretru = self.man.retr(x, u)
         np_testing.assert_allclose(xretru, x + u)
 
-        # def test_transp(self):
+    def test_transp(self):
+        # check that vector remains in tangent space
+        m = self.man
+        x = m.rand()
+        y = m.rand()
+        u = m.randvec(x)
+        t_u = m.transp(x, y, u)
+        np_testing.assert_allclose(t_u, m.proj(y, t_u))
+
+
+class TestProductStrictlyPositiveVectors():
+    def __init__(self):
+        self.n = n = 10
+        self.k = k = 2
+        self.man = StrictlyPositiveVectors(n, k=k)
+
+    def test_inner(self):
+        x = self.man.rand()
+        g = 2 * self.man.randvec(x)
+        h = 3 * self.man.randvec(x)
+        assert type(self.man.inner(x, g, h)) is np.float64
+
+    def test_proj(self):
+        # Test proj(proj(X)) == proj(X)
+        x = self.man.rand()
+        u = rnd.randn(self.n)
+        proj_u = self.man.proj(x, u)
+        proj_proj_u = self.man.proj(x, proj_u)
+
+        np_testing.assert_allclose(proj_u, proj_proj_u)
+
+    def test_norm(self):
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        x_u = (1.0 / x) * u
+        assert type(self.man.norm(x, u)) is np.float64
+        np_testing.assert_allclose(la.norm(x_u), self.man.norm(x, u))
+
+    def test_rand(self):
+        # Just make sure that things generated are on the manifold
+        # and that if you generate two they are not equal.
+        k, n = self.k, self.n
+        x = self.man.rand()
+        assert x.shape == (k, n, 1)
+        assert (x > 0).all()
+        y = self.man.rand()
+        assert (self.man.dist(x, y)).all() > 1e-6
+
+    def test_randvec(self):
+        # Just make sure that if you generate two they are not equal.
+        # check also if unit norm
+        k, n = self.k, self.n
+        x = self.man.rand()
+        g = self.man.randvec(x)
+        assert g.shape == (k, n, 1)
+        h = self.man.randvec(x)
+        assert (la.norm(g - h, axis=0) > 1e-6).all()
+        np_testing.assert_allclose(self.man.norm(x, g), 1)
+
+    def test_zerovec(self):
+        x = self.man.rand()
+        np_testing.assert_allclose(
+            self.man.zerovec(x),
+            np.zeros((self.k, self.n, 1))
+        )
+
+    def test_dist(self):
+        # To implement norm of log(x, y)
+        x = self.man.rand()
+        y = self.man.rand()
+        u = self.man.log(x, y)
+        assert type(self.man.dist(x, y)) is np.float64
+        np_testing.assert_allclose(self.man.norm(x, u),
+                                   self.man.dist(x, y))
+
+    def test_ehess2rhess(self):
+        k, n = self.k, self.n
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        egrad = rnd.normal(size=(k, n, 1))
+        ehess = rnd.normal(size=(k, n, 1))
+        hess = self.man.ehess2rhess(x, egrad, ehess, u)
+        hess_proj = self.man.proj(x, hess)
+
+        np_testing.assert_allclose(hess, hess_proj)
+
+    def test_exp_log_inverse(self):
+        x = self.man.rand()
+        y = self.man.rand()
+        u = self.man.log(x, y)
+        z = self.man.exp(x, u)
+        np_testing.assert_allclose(self.man.dist(y, z), 0, atol=1e-10)
+
+    def test_log_exp_inverse(self):
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        y = self.man.exp(x, u)
+        v = self.man.log(x, y)
+        np_testing.assert_allclose(self.man.norm(x, u - v), 0, atol=1e-10)
+
+    def test_retr(self):
+        # Test that the result is on the manifold and that for small
+        # tangent vectors it has little effect.
+        x = self.man.rand()
+        u = self.man.randvec(x)
+
+        xretru = self.man.retr(x, u)
+
+        assert (xretru > 0).all()
+
+        u = u * 1e-6
+        xretru = self.man.retr(x, u)
+        np_testing.assert_allclose(xretru, x + u)
+
+    def test_transp(self):
+        # check that vector remains in tangent space
+        m = self.man
+        x = m.rand()
+        y = m.rand()
+        u = m.randvec(x)
+        t_u = m.transp(x, y, u)
+        np_testing.assert_allclose(t_u, m.proj(y, t_u))

--- a/tests/test_manifolds/test_strictly_positive_vectors.py
+++ b/tests/test_manifolds/test_strictly_positive_vectors.py
@@ -19,7 +19,7 @@ class TestSingleStrictlyPositiveVectors(TestCase):
         x = self.man.rand()
         g = 2 * self.man.randvec(x)
         h = 3 * self.man.randvec(x)
-        assert type(self.man.inner(x, g, h)) is np.float64
+        assert isinstance(self.man.inner(x, g, h), np.float64)
 
     def test_proj(self):
         # Test proj(proj(X)) == proj(X)
@@ -34,7 +34,7 @@ class TestSingleStrictlyPositiveVectors(TestCase):
         x = self.man.rand()
         u = self.man.randvec(x)
         x_u = (1.0 / x) * u
-        assert type(self.man.norm(x, u)) is np.float64
+        assert isinstance(self.man.norm(x, u), np.float64)
         np_testing.assert_allclose(la.norm(x_u), self.man.norm(x, u))
 
     def test_rand(self):
@@ -67,7 +67,7 @@ class TestSingleStrictlyPositiveVectors(TestCase):
         x = self.man.rand()
         y = self.man.rand()
         u = self.man.log(x, y)
-        assert type(self.man.dist(x, y)) is np.float64
+        assert isinstance(self.man.dist(x, y), np.float64)
         np_testing.assert_allclose(self.man.norm(x, u), self.man.dist(x, y))
 
     def test_ehess2rhess(self):
@@ -129,7 +129,7 @@ class TestProductStrictlyPositiveVectors:
         x = self.man.rand()
         g = 2 * self.man.randvec(x)
         h = 3 * self.man.randvec(x)
-        assert type(self.man.inner(x, g, h)) is np.float64
+        assert isinstance(self.man.inner(x, g, h), np.float64)
 
     def test_proj(self):
         # Test proj(proj(X)) == proj(X)
@@ -144,7 +144,7 @@ class TestProductStrictlyPositiveVectors:
         x = self.man.rand()
         u = self.man.randvec(x)
         x_u = (1.0 / x) * u
-        assert type(self.man.norm(x, u)) is np.float64
+        assert isinstance(self.man.norm(x, u), np.float64)
         np_testing.assert_allclose(la.norm(x_u), self.man.norm(x, u))
 
     def test_rand(self):
@@ -179,7 +179,7 @@ class TestProductStrictlyPositiveVectors:
         x = self.man.rand()
         y = self.man.rand()
         u = self.man.log(x, y)
-        assert type(self.man.dist(x, y)) is np.float64
+        assert isinstance(self.man.dist(x, y), np.float64)
         np_testing.assert_allclose(self.man.norm(x, u), self.man.dist(x, y))
 
     def test_ehess2rhess(self):


### PR DESCRIPTION
As discussed in #113, some functions (such as `inner` ,`norm`  and `dist`) of the StrictlyPositiveVectors manifold return arrays instead of scalars. This pr fixes this problem. It also adds `ehess2rhess`, a second order retraction and a parallel transport.