### PR TITLE
Replace calls to 'multiprod' with direct matrix multiplication

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO/Roadmap
 
 ## 1.1.x:
-  - Replace 'multiprod' with bare @-operator
   - Use weingarten map for fixed rank manifold
   - Change "beta_rule" of CG optimizer to internal enum representation
   - Add re-tangentialization change from manopt's trustregions solver

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 # TODO/Roadmap
 
 ## 1.1.x:
-  - Use weingarten map for fixed rank manifold
   - Change "beta_rule" of CG optimizer to internal enum representation
   - Add re-tangentialization change from manopt's trustregions solver
     (requires adding implementation for `to_tangent_space` for each manifold)
@@ -23,6 +22,8 @@
   - Add callback mechanism to allow for custom termination criteria
 
 ## 2.0.x:
+  - Make FixedRankEmbedded manifold compatible with autodiff backends
+    (add weingarten map to support euclidean_to_riemannian_hessian)
   - Refactor TrustRegions implementation and update parameter names
   - Rewrite core/manifolds
     * in JAX with jit support, or

--- a/pymanopt/manifolds/grassmann.py
+++ b/pymanopt/manifolds/grassmann.py
@@ -79,7 +79,7 @@ class Grassmann(_GrassmannBase):
         )
 
     def projection(self, point, vector):
-        return vector - point @ multitransp(point) @ vector
+        return vector - point @ (multitransp(point) @ vector)
 
     def euclidean_to_riemannian_hessian(
         self, point, euclidean_gradient, euclidean_hessian, tangent_vector

--- a/pymanopt/manifolds/grassmann.py
+++ b/pymanopt/manifolds/grassmann.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from pymanopt.manifolds.manifold import Manifold
-from pymanopt.tools.multi import multihconj, multiprod, multiqr, multitransp
+from pymanopt.tools.multi import multihconj, multiqr, multitransp
 
 
 class _GrassmannBase(Manifold):
@@ -68,9 +68,7 @@ class Grassmann(_GrassmannBase):
         super().__init__(name, dimension)
 
     def dist(self, point_a, point_b):
-        s = np.linalg.svd(
-            multiprod(multitransp(point_a), point_b), compute_uv=False
-        )
+        s = np.linalg.svd(multitransp(point_a) @ point_b, compute_uv=False)
         s[s > 1] = 1
         s = np.arccos(s)
         return np.linalg.norm(s)
@@ -81,14 +79,14 @@ class Grassmann(_GrassmannBase):
         )
 
     def projection(self, point, vector):
-        return vector - multiprod(point, multiprod(multitransp(point), vector))
+        return vector - point @ multitransp(point) @ vector
 
     def euclidean_to_riemannian_hessian(
         self, point, euclidean_gradient, euclidean_hessian, tangent_vector
     ):
         PXehess = self.projection(point, euclidean_hessian)
-        XtG = multiprod(multitransp(point), euclidean_gradient)
-        HXtG = multiprod(tangent_vector, XtG)
+        XtG = multitransp(point) @ euclidean_gradient
+        HXtG = tangent_vector @ XtG
         return PXehess - HXtG
 
     def retraction(self, point, tangent_vector):
@@ -98,7 +96,7 @@ class Grassmann(_GrassmannBase):
 
         # Compute the polar factorization of Y = X+G
         u, _, vt = np.linalg.svd(point + tangent_vector, full_matrices=False)
-        return multiprod(u, vt)
+        return u @ vt
 
     def random_point(self):
         q, _ = multiqr(np.random.normal(size=(self._k, self._n, self._p)))
@@ -116,9 +114,7 @@ class Grassmann(_GrassmannBase):
         cos_s = np.expand_dims(np.cos(s), -2)
         sin_s = np.expand_dims(np.sin(s), -2)
 
-        Y = multiprod(
-            multiprod(point, multitransp(vt) * cos_s), vt
-        ) + multiprod(u * sin_s, vt)
+        Y = point @ (multitransp(vt) * cos_s) @ vt + (u * sin_s) @ vt
 
         # From numerical experiments, it seems necessary to re-orthonormalize.
         # This is quite expensive.
@@ -126,12 +122,12 @@ class Grassmann(_GrassmannBase):
         return q
 
     def log(self, point_a, point_b):
-        ytx = multiprod(multitransp(point_b), point_a)
-        At = multitransp(point_b) - multiprod(ytx, multitransp(point_a))
+        ytx = multitransp(point_b) @ point_a
+        At = multitransp(point_b) - ytx @ multitransp(point_a)
         Bt = np.linalg.solve(ytx, At)
         u, s, vt = np.linalg.svd(multitransp(Bt), full_matrices=False)
         arctan_s = np.expand_dims(np.arctan(s), -2)
-        return multiprod(u * arctan_s, vt)
+        return (u * arctan_s) @ vt
 
 
 class ComplexGrassmann(_GrassmannBase):
@@ -176,9 +172,7 @@ class ComplexGrassmann(_GrassmannBase):
         super().__init__(name, dimension)
 
     def dist(self, point_a, point_b):
-        s = np.linalg.svd(
-            multiprod(multihconj(point_a), point_b), compute_uv=False
-        )
+        s = np.linalg.svd(multihconj(point_a) @ point_b, compute_uv=False)
         s[s > 1] = 1
         s = np.arccos(s)
         return np.linalg.norm(np.real(s))
@@ -193,14 +187,14 @@ class ComplexGrassmann(_GrassmannBase):
         )
 
     def projection(self, point, vector):
-        return vector - multiprod(point, multiprod(multihconj(point), vector))
+        return vector - point @ multihconj(point) @ vector
 
     def euclidean_to_riemannian_hessian(
         self, point, euclidean_gradient, euclidean_hessian, tangent_vector
     ):
         PXehess = self.projection(point, euclidean_hessian)
-        XHG = multiprod(multihconj(point), euclidean_gradient)
-        HXHG = multiprod(tangent_vector, XHG)
+        XHG = multihconj(point) @ euclidean_gradient
+        HXHG = tangent_vector @ XHG
         return PXehess - HXHG
 
     def retraction(self, point, tangent_vector):
@@ -210,7 +204,7 @@ class ComplexGrassmann(_GrassmannBase):
 
         # Compute the polar factorization of Y = X+G
         u, _, vh = np.linalg.svd(point + tangent_vector, full_matrices=False)
-        return multiprod(u, vh)
+        return u @ vh
 
     def random_point(self):
         q, _ = multiqr(
@@ -232,9 +226,7 @@ class ComplexGrassmann(_GrassmannBase):
         U, S, VH = np.linalg.svd(tangent_vector, full_matrices=False)
         cos_S = np.expand_dims(np.cos(S), -2)
         sin_S = np.expand_dims(np.sin(S), -2)
-        Y = multiprod(
-            multiprod(point, multihconj(VH) * cos_S), VH
-        ) + multiprod(U * sin_S, VH)
+        Y = point @ (multihconj(VH) * cos_S) @ VH + (U * sin_S) @ VH
 
         # From numerical experiments, it seems necessary to
         # re-orthonormalize. This is overall quite expensive.
@@ -242,9 +234,9 @@ class ComplexGrassmann(_GrassmannBase):
         return q
 
     def log(self, point_a, point_b):
-        YHX = multiprod(multihconj(point_b), point_a)
-        AH = multihconj(point_b) - multiprod(YHX, multihconj(point_a))
+        YHX = multihconj(point_b) @ point_a
+        AH = multihconj(point_b) - YHX @ multihconj(point_a)
         BH = np.linalg.solve(YHX, AH)
         U, S, VH = np.linalg.svd(multihconj(BH), full_matrices=False)
         arctan_S = np.expand_dims(np.arctan(S), -2)
-        return multiprod(U * arctan_S, VH)
+        return (U * arctan_S) @ VH

--- a/pymanopt/manifolds/special_orthogonal_group.py
+++ b/pymanopt/manifolds/special_orthogonal_group.py
@@ -5,7 +5,6 @@ from pymanopt.manifolds.manifold import RiemannianSubmanifold
 from pymanopt.tools.multi import (
     multiexpm,
     multilogm,
-    multiprod,
     multiqr,
     multiskew,
     multisym,
@@ -85,41 +84,41 @@ class SpecialOrthogonalGroup(RiemannianSubmanifold):
         return self.norm(point_a, self.log(point_a, point_b))
 
     def projection(self, point, vector):
-        return multiskew(multiprod(multitransp(point), vector))
+        return multiskew(multitransp(point) @ vector)
 
     def to_tangent_space(self, point, vector):
         return multiskew(vector)
 
     def embedding(self, point, tangent_vector):
-        return multiprod(point, tangent_vector)
+        return point @ tangent_vector
 
     def euclidean_to_riemannian_hessian(
         self, point, euclidean_gradient, euclidean_hessian, tangent_vector
     ):
         Xt = multitransp(point)
-        Xtegrad = multiprod(Xt, euclidean_gradient)
+        Xtegrad = Xt @ euclidean_gradient
         symXtegrad = multisym(Xtegrad)
-        Xtehess = multiprod(Xt, euclidean_hessian)
-        return multiskew(Xtehess - multiprod(tangent_vector, symXtegrad))
+        Xtehess = Xt @ euclidean_hessian
+        return multiskew(Xtehess - tangent_vector @ symXtegrad)
 
     def retraction(self, point, tangent_vector):
         return self._retraction(point, tangent_vector)
 
     def _retraction_qr(self, point, tangent_vector):
-        Y = point + multiprod(point, tangent_vector)
+        Y = point + point @ tangent_vector
         q, _ = multiqr(Y)
         return q
 
     def _retraction_polar(self, point, tangent_vector):
-        Y = point + multiprod(point, tangent_vector)
+        Y = point + point @ tangent_vector
         u, _, vt = np.linalg.svd(Y)
-        return multiprod(u, vt)
+        return u @ vt
 
     def exp(self, point, tangent_vector):
-        return multiprod(point, multiexpm(tangent_vector))
+        return point @ multiexpm(tangent_vector)
 
     def log(self, point_a, point_b):
-        U = multiprod(multitransp(point_a), point_b)
+        U = multitransp(point_a) @ point_b
         return multiskew(multilogm(U))
 
     def random_point(self):

--- a/pymanopt/manifolds/stiefel.py
+++ b/pymanopt/manifolds/stiefel.py
@@ -118,7 +118,7 @@ class Stiefel(RiemannianSubmanifold):
         return self.projection(point_b, tangent_vector_a)
 
     def exp(self, point, tangent_vector):
-        A = multitransp(point) @ tangent_vector
+        pt_tv = multitransp(point) @ tangent_vector
         if self._k == 1:
             identity = np.eye(self._p)
         else:
@@ -129,14 +129,15 @@ class Stiefel(RiemannianSubmanifold):
             np.block(
                 [
                     [
-                        A,
+                        pt_tv,
                         -multitransp(tangent_vector) @ tangent_vector,
                     ],
-                    [identity, A],
+                    [identity, pt_tv],
                 ]
             )
-        )
-        return a @ b[..., : self._p] @ multiexpm(-A)
+        )[..., : self._p]
+        c = multiexpm(-pt_tv)
+        return a @ (b @ c)
 
     def zero_vector(self, point):
         if self._k == 1:

--- a/pymanopt/tools/multi.py
+++ b/pymanopt/tools/multi.py
@@ -2,30 +2,6 @@ import numpy as np
 import scipy.linalg
 
 
-def multiprod(A: np.ndarray, B: np.ndarray) -> np.ndarray:
-    """Vectorized matrix-matrix multiplication.
-
-    The matrices ``A`` and ``B`` are assumed to be arrays containing ``k``
-    matrices, i.e., ``A`` and ``B`` have shape ``(k, m, n)`` and ``(k, n, p)``,
-    respectively.
-    The function multiplies each matrix in ``A`` with the corresponding matrix
-    in ``B`` along the first dimension.
-    The resulting array has shape ``(k, m, p)``.
-
-    Args:
-        A: The first matrix.
-        B: The second matrix.
-
-    Returns:
-        The matrix (or more precisely array of matrices) corresponding to
-        the matrix product vectorized over the first dimension of ``A`` and
-        ``B`` (if ``A.ndim == 2``).
-    """
-    if A.ndim == 2:
-        return A @ B
-    return np.einsum("ijk,ikl->ijl", A, B)
-
-
 def multitransp(A):
     """Vectorized matrix transpose.
 
@@ -77,7 +53,7 @@ def multilogm(A, *, positive_definite=False):
 
     w, v = np.linalg.eigh(A)
     w = np.expand_dims(np.log(w), axis=-1)
-    logmA = multiprod(v, w * multihconj(v))
+    logmA = v @ (w * multihconj(v))
     if np.isrealobj(A):
         return np.real(logmA)
     return logmA
@@ -90,7 +66,7 @@ def multiexpm(A, *, symmetric=False):
 
     w, v = np.linalg.eigh(A)
     w = np.expand_dims(np.exp(w), axis=-1)
-    expmA = multiprod(v, w * multihconj(v))
+    expmA = v @ (w * multihconj(v))
     if np.isrealobj(A):
         return np.real(expmA)
     return expmA

--- a/tests/manifolds/test_complex_grassmann.py
+++ b/tests/manifolds/test_complex_grassmann.py
@@ -2,7 +2,7 @@ import autograd.numpy as np
 from numpy import testing as np_testing
 
 from pymanopt.manifolds import ComplexGrassmann
-from pymanopt.tools.multi import multieye, multihconj, multiprod, multisym
+from pymanopt.tools.multi import multieye, multihconj, multisym
 
 from .._test import TestCase
 
@@ -39,7 +39,7 @@ class TestSingleComplexGrassmannManifold(TestCase):
         np_testing.assert_allclose(proj_U, proj_proj_U)
 
         np_testing.assert_allclose(
-            multiprod(multihconj(X), proj_U),
+            multihconj(X) @ proj_U,
             np.zeros((self.n, self.n)),
             atol=1e-10,
         )
@@ -58,7 +58,7 @@ class TestSingleComplexGrassmannManifold(TestCase):
         # Test also that matrices are complex.
         X = self.manifold.random_point()
         np_testing.assert_allclose(
-            multiprod(multihconj(X), X), np.eye(self.n), atol=1e-10
+            multihconj(X) @ X, np.eye(self.n), atol=1e-10
         )
         Y = self.manifold.random_point()
         assert np.linalg.norm(X - Y) > 1e-6
@@ -72,7 +72,7 @@ class TestSingleComplexGrassmannManifold(TestCase):
         X = self.manifold.random_point()
         G = self.manifold.random_tangent_vector(X)
         np_testing.assert_allclose(
-            multiprod(multihconj(X), G), np.zeros((self.n, self.n)), atol=1e-10
+            multihconj(X) @ G, np.zeros((self.n, self.n)), atol=1e-10
         )
         H = self.manifold.random_tangent_vector(X)
         assert np.linalg.norm(G - H) > 1e-6
@@ -111,7 +111,7 @@ class TestSingleComplexGrassmannManifold(TestCase):
         xretru = self.manifold.retraction(x, u)
 
         np_testing.assert_allclose(
-            multiprod(multihconj(xretru), xretru), np.eye(self.n), atol=1e-10
+            multihconj(xretru) @ xretru, np.eye(self.n), atol=1e-10
         )
 
         u = u * 1e-6
@@ -159,7 +159,7 @@ class TestMultiComplexGrassmannManifold(TestCase):
         np_testing.assert_allclose(proj_U, proj_proj_U)
 
         np_testing.assert_allclose(
-            multiprod(multihconj(X), proj_U),
+            multihconj(X) @ proj_U,
             np.zeros((self.k, self.n, self.n)),
             atol=1e-10,
         )
@@ -177,7 +177,7 @@ class TestMultiComplexGrassmannManifold(TestCase):
         # if you generate two they are not equal.
         X = self.manifold.random_point()
         np_testing.assert_allclose(
-            multiprod(multihconj(X), X), multieye(self.k, self.n), atol=1e-10
+            multihconj(X) @ X, multieye(self.k, self.n), atol=1e-10
         )
         Y = self.manifold.random_point()
         assert np.linalg.norm(X - Y) > 1e-6
@@ -189,7 +189,7 @@ class TestMultiComplexGrassmannManifold(TestCase):
         X = self.manifold.random_point()
         U = self.manifold.random_tangent_vector(X)
         np_testing.assert_allclose(
-            multisym(multiprod(multihconj(X), U)),
+            multisym(multihconj(X) @ U),
             np.zeros((self.k, self.n, self.n)),
             atol=1e-10,
         )
@@ -230,7 +230,7 @@ class TestMultiComplexGrassmannManifold(TestCase):
         xretru = self.manifold.retraction(x, u)
 
         np_testing.assert_allclose(
-            multiprod(multihconj(xretru), xretru),
+            multihconj(xretru) @ xretru,
             multieye(self.k, self.n),
             atol=1e-10,
         )

--- a/tests/manifolds/test_grassmann.py
+++ b/tests/manifolds/test_grassmann.py
@@ -3,7 +3,7 @@ from numpy import testing as np_testing
 
 from pymanopt.manifolds import Grassmann
 from pymanopt.tools import testing
-from pymanopt.tools.multi import multieye, multiprod, multisym, multitransp
+from pymanopt.tools.multi import multieye, multisym, multitransp
 
 from .._test import TestCase
 
@@ -48,7 +48,7 @@ class TestSingleGrassmannManifold(TestCase):
         xretru = self.manifold.retraction(x, u)
 
         np_testing.assert_allclose(
-            multiprod(multitransp(xretru), xretru), np.eye(self.n), atol=1e-10
+            multitransp(xretru) @ xretru, np.eye(self.n), atol=1e-10
         )
 
         u = u * 1e-6
@@ -64,7 +64,7 @@ class TestSingleGrassmannManifold(TestCase):
         # if you generate two they are not equal.
         X = self.manifold.random_point()
         np_testing.assert_allclose(
-            multiprod(multitransp(X), X), np.eye(self.n), atol=1e-10
+            multitransp(X) @ X, np.eye(self.n), atol=1e-10
         )
         Y = self.manifold.random_point()
         assert np.linalg.norm(X - Y) > 1e-6
@@ -140,7 +140,7 @@ class TestMultiGrassmannManifold(TestCase):
         H = np.random.normal(size=(self.k, self.m, self.n))
 
         # Compare the projections.
-        Hproj = H - multiprod(X, multiprod(multitransp(X), H))
+        Hproj = H - X @ multitransp(X) @ H
         np_testing.assert_allclose(Hproj, self.manifold.projection(X, H))
 
     def test_retraction(self):
@@ -152,7 +152,7 @@ class TestMultiGrassmannManifold(TestCase):
         xretru = self.manifold.retraction(x, u)
 
         np_testing.assert_allclose(
-            multiprod(multitransp(xretru), xretru),
+            multitransp(xretru) @ xretru,
             multieye(self.k, self.n),
             atol=1e-10,
         )
@@ -175,7 +175,7 @@ class TestMultiGrassmannManifold(TestCase):
         # if you generate two they are not equal.
         X = self.manifold.random_point()
         np_testing.assert_allclose(
-            multiprod(multitransp(X), X), multieye(self.k, self.n), atol=1e-10
+            multitransp(X) @ X, multieye(self.k, self.n), atol=1e-10
         )
         Y = self.manifold.random_point()
         assert np.linalg.norm(X - Y) > 1e-6
@@ -186,7 +186,7 @@ class TestMultiGrassmannManifold(TestCase):
         X = self.manifold.random_point()
         U = self.manifold.random_tangent_vector(X)
         np_testing.assert_allclose(
-            multisym(multiprod(multitransp(X), U)),
+            multisym(multitransp(X) @ U),
             np.zeros((self.k, self.n, self.n)),
             atol=1e-10,
         )

--- a/tests/manifolds/test_special_orthogonal_group.py
+++ b/tests/manifolds/test_special_orthogonal_group.py
@@ -3,7 +3,7 @@ import numpy.testing as np_testing
 from nose2.tools import params
 
 from pymanopt.manifolds import SpecialOrthogonalGroup
-from pymanopt.tools.multi import multieye, multiprod, multitransp
+from pymanopt.tools.multi import multieye, multitransp
 
 from .._test import TestCase
 
@@ -26,12 +26,11 @@ class TestSpecialOrthogonalGroup(TestCase):
         point = self.so_product.random_point()
         assert point.shape == (self.k, self.n, self.n)
         np_testing.assert_almost_equal(
-            multiprod(multitransp(point), point)
-            - multiprod(point, multitransp(point)),
+            multitransp(point) @ point - point @ multitransp(point),
             0,
         )
         np_testing.assert_almost_equal(
-            multiprod(multitransp(point), point), multieye(self.k, self.n)
+            multitransp(point) @ point, multieye(self.k, self.n)
         )
         assert np.allclose(np.linalg.det(point), 1)
 

--- a/tests/manifolds/test_stiefel.py
+++ b/tests/manifolds/test_stiefel.py
@@ -4,7 +4,7 @@ from numpy import testing as np_testing
 
 from pymanopt.manifolds import Stiefel
 from pymanopt.tools import testing
-from pymanopt.tools.multi import multieye, multiprod, multisym, multitransp
+from pymanopt.tools.multi import multieye, multisym, multitransp
 
 from .._test import TestCase
 
@@ -170,13 +170,7 @@ class TestMultiStiefelManifold(TestCase):
         H = np.random.normal(size=(self.k, self.m, self.n))
 
         # Compare the projections.
-        Hproj = (
-            H
-            - multiprod(
-                X, multiprod(multitransp(X), H) + multiprod(multitransp(H), X)
-            )
-            / 2
-        )
+        Hproj = H - X @ (multitransp(X) @ H + multitransp(H) @ X) / 2
         np_testing.assert_allclose(Hproj, self.manifold.projection(X, H))
 
     def test_random_point(self):
@@ -184,7 +178,7 @@ class TestMultiStiefelManifold(TestCase):
         # if you generate two they are not equal.
         X = self.manifold.random_point()
         np_testing.assert_allclose(
-            multiprod(multitransp(X), X), multieye(self.k, self.n), atol=1e-10
+            multitransp(X) @ X, multieye(self.k, self.n), atol=1e-10
         )
         Y = self.manifold.random_point()
         assert np.linalg.norm(X - Y) > 1e-6
@@ -195,7 +189,7 @@ class TestMultiStiefelManifold(TestCase):
         X = self.manifold.random_point()
         U = self.manifold.random_tangent_vector(X)
         np_testing.assert_allclose(
-            multisym(multiprod(multitransp(X), U)),
+            multisym(multitransp(X) @ U),
             np.zeros((self.k, self.n, self.n)),
             atol=1e-10,
         )
@@ -214,7 +208,7 @@ class TestMultiStiefelManifold(TestCase):
         xretru = manifold.retraction(x, u)
 
         np_testing.assert_allclose(
-            multiprod(multitransp(xretru), xretru),
+            multitransp(xretru) @ xretru,
             multieye(self.k, self.n),
             atol=1e-10,
         )
@@ -239,7 +233,7 @@ class TestMultiStiefelManifold(TestCase):
 
         xexpu = s.exp(x, u)
         np_testing.assert_allclose(
-            multiprod(multitransp(xexpu), xexpu),
+            multitransp(xexpu) @ xexpu,
             multieye(self.k, self.n),
             atol=1e-10,
         )

--- a/tests/test_multi_tools.py
+++ b/tests/test_multi_tools.py
@@ -7,7 +7,6 @@ from pymanopt.tools.multi import (
     multieye,
     multihconj,
     multilogm,
-    multiprod,
     multiqr,
     multisym,
     multitransp,
@@ -22,25 +21,6 @@ class TestMulti(TestCase):
         self.n = 50
         self.p = 40
         self.k = 10
-
-    def test_multiprod_singlemat(self):
-        # Two random matrices A (m x n) and B (n x p)
-        A = np.random.normal(size=(self.m, self.n))
-        B = np.random.normal(size=(self.n, self.p))
-
-        # Compare the products.
-        np_testing.assert_allclose(A @ B, multiprod(A, B))
-
-    def test_multiprod(self):
-        # Two random arrays of matrices A (k x m x n) and B (k x n x p)
-        A = np.random.normal(size=(self.k, self.m, self.n))
-        B = np.random.normal(size=(self.k, self.n, self.p))
-
-        C = np.zeros((self.k, self.m, self.p))
-        for i in range(self.k):
-            C[i] = A[i] @ B[i]
-
-        np_testing.assert_allclose(C, multiprod(A, B))
 
     def test_multitransp_singlemat(self):
         A = np.random.normal(size=(self.m, self.n))
@@ -93,7 +73,7 @@ class TestMulti(TestCase):
     def test_multilogm_complex_positive_definite(self):
         shape = (self.k, self.m, self.m)
         A = np.random.normal(size=shape) + 1j * np.random.normal(size=shape)
-        A = multiprod(A, multihconj(A))
+        A = A @ multihconj(A)
         # Compare fast path for positive definite matrices vs. general slow
         # one.
         np_testing.assert_allclose(
@@ -128,10 +108,10 @@ class TestMulti(TestCase):
         shape = (self.k, self.m, self.m)
         A_real = np.random.normal(size=shape)
         q, r = multiqr(A_real)
-        np_testing.assert_allclose(multiprod(q, r), A_real)
+        np_testing.assert_allclose(q @ r, A_real)
 
         A_complex = np.random.normal(size=shape) + 1j * np.random.normal(
             size=shape
         )
         q, r = multiqr(A_complex)
-        np_testing.assert_allclose(multiprod(q, r), A_complex)
+        np_testing.assert_allclose(q @ r, A_complex)


### PR DESCRIPTION
The matrix multiplication operator `@` (being the same as `np.matmul`) already has the necessary semantic to perform stacked matrix multiplication. As such, an indirection of matrix multiplication for product manifolds via `multiprod` on top of `np.einsum` is not necessary.