### PR TITLE
Add Poincare ball model

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,10 @@
 ## 1.1.x:
   - Add re-tangentialization change from manopt's trustregions solver
     (requires adding implementation for `to_tangent_space` for each manifold)
+  - Add test cases for 'euclidean_to_riemannian_gradient' based on
+    'check_gradient' diagnostic function
+  - Add 'check_hessian' diagnostic function to add automatic tests for
+    `euclidean_to_riemannian_hessian'
 
 ## 1.2.x:
   - For Riemannian submanifolds of Euclidean space, it is acceptable to

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,7 @@ latex_macros = r"""
     \def \conj   #1{#1^*}
     \def \norm   #1{\|#1\|}
     \def \abs    #1{|#1|}
+    \def \parens #1{\left(#1\right)}
 """
 # Generate macros for boldface letters.
 latex_macros += "\n".join(
@@ -130,7 +131,13 @@ katex_options = (
     + "\n"
     + r'"\\argmin":'
     + r'"\\mathop{\\operatorname{argmin}}\\limits"'
+    + ",\n"
+    + r'"\\arccosh":'
+    + r'"\\operatorname{arccosh}"'
+    + ",\n"
+    + r'"\\dist":'
+    + r'"\\operatorname{dist}"'
     + "}"
 )
-print(f"Defined KaTeX macros:\n{katex_macros}")
+print(f"Defined KaTeX macros:\n{katex_options}")
 latex_elements = {"preamble": latex_macros}

--- a/docs/manifolds.rst
+++ b/docs/manifolds.rst
@@ -84,6 +84,11 @@ Positive Matrices
 
 .. automodule:: pymanopt.manifolds.positive
 
+Hyperbolic Space
+----------------
+
+.. automodule:: pymanopt.manifolds.hyperbolic
+
 Product Manifold
 ----------------
 

--- a/pymanopt/manifolds/__init__.py
+++ b/pymanopt/manifolds/__init__.py
@@ -6,9 +6,10 @@ __all__ = [
     "FixedRankEmbedded",
     "Grassmann",
     "Oblique",
-    "Positive",
     "PSDFixedRank",
     "PSDFixedRankComplex",
+    "PoincareBall",
+    "Positive",
     "Product",
     "SkewSymmetric",
     "SpecialOrthogonalGroup",
@@ -24,6 +25,7 @@ from .complex_circle import ComplexCircle
 from .euclidean import Euclidean, SkewSymmetric, Symmetric
 from .fixed_rank import FixedRankEmbedded
 from .grassmann import ComplexGrassmann, Grassmann
+from .hyperbolic import PoincareBall
 from .oblique import Oblique
 from .positive import Positive
 from .positive_definite import SymmetricPositiveDefinite

--- a/pymanopt/manifolds/hyperbolic.py
+++ b/pymanopt/manifolds/hyperbolic.py
@@ -74,30 +74,27 @@ class PoincareBall(Manifold):
 
     def random_point(self):
         array = np.random.normal(size=(self._k, self._n))
-        norms = np.linalg.norm(array, axis=-1, keepdims=True)
-        radiuses = np.random.uniform(size=(self._k, 1)) ** (1.0 / self._n)
-        point = array / norms * radiuses
+        norm = np.linalg.norm(array, axis=-1, keepdims=True)
+        radius = np.random.uniform(size=(self._k, 1)) ** (1.0 / self._n)
+        point = array / norm * radius
         if self._k == 1:
             return point[0]
         return point
 
     def random_tangent_vector(self, point):
-        return np.random.normal(size=np.shape(point))
+        return np.random.normal(size=point.shape)
 
     def zero_vector(self, point):
         return np.zeros_like(point)
 
     def dist(self, point_a, point_b):
-        norms2_point_a = np.sum(point_a * point_a, axis=-1)
-        norms2_point_b = np.sum(point_b * point_b, axis=-1)
+        norm_point_a = np.sum(point_a * point_a, axis=-1)
+        norm_point_b = np.sum(point_b * point_b, axis=-1)
         difference = point_a - point_b
-        norms2_difference = np.sum(difference * difference, axis=-1)
+        norm_difference = np.sum(difference * difference, axis=-1)
 
         columns_dist = np.arccosh(
-            1
-            + 2
-            * norms2_difference
-            / ((1 - norms2_point_a) * (1 - norms2_point_b))
+            1 + 2 * norm_difference / ((1 - norm_point_a) * (1 - norm_point_b))
         )
         return np.linalg.norm(columns_dist)
 

--- a/pymanopt/manifolds/hyperbolic.py
+++ b/pymanopt/manifolds/hyperbolic.py
@@ -6,19 +6,21 @@ from pymanopt.manifolds.manifold import Manifold
 class PoincareBall(Manifold):
     r"""The Poincare ball.
 
-    An instance represents the Cartesian product of n (defaults to 1)
-    Poincare balls of dimension k.
-    Elements are represented as matrices of size k x n, or arrays of
-    size k if n = 1.
+    The Poincare ball of dimension ``n``.
+    Elements are represented as arrays of shape ``(n,)`` if ``k = 1``.
+    For ``k > 1``, the class represents the product manifold of ``k`` Poincare
+    balls of dimension ``n``, in which case points are represented as arrays of
+    shape ``(k, n)``.
 
-    The Poincare ball is embedded in R^k and is a Riemannian manifold,
-    but it is not an embedded Riemannian submanifold.
-    At every point x, the tangent space at x is R^k since the manifold
-    is open.
+    Since the manifold is open, the tangent space at every point is a copy of
+    :math:`\R^n`.
 
-    The metric is conformal to the Euclidean one (angles are preserved),
-    and it is given at every point :math:`\vmx` by
-    :math:`\inner{\vmu}{\vmv}_\vmx = \lambda_\vmx \inner{\vmu}{\vmv}` where
+    The Poincare ball is embedded in :math:`\R^n` and is a Riemannian manifold,
+    but it is not an embedded Riemannian submanifold since the metric is not
+    inherited from the Euclidean inner product of its ambient space.
+    Instead, the Riemannian metric is conformal to the Euclidean one (angles are
+    preserved), and it is given at every point :math:`\vmx` by
+    :math:`\inner{\vmu}{\vmv}_\vmx = \lambda_\vmx^2 \inner{\vmu}{\vmv}` where
     :math:`\lambda_\vmx = 2 / (1 - \norm{\vmx}^2)` is the conformal factor.
     This induces the following distance between two points :math:`\vmx` and
     :math:`\vmy` on the manifold:
@@ -27,6 +29,10 @@ class PoincareBall(Manifold):
         - \vmy}^2}{(1 - \norm{\vmx}^2) (1 - \norm{\vmy}^2)}}.`
 
     The norm here is understood as the Euclidean norm in the ambient space.
+
+    Args:
+        n: The dimension of the Poincare ball.
+        k: The number of elements in the product of Poincare balls.
     """
 
     def __init__(self, n: int, *, k: int = 1):

--- a/pymanopt/manifolds/hyperbolic.py
+++ b/pymanopt/manifolds/hyperbolic.py
@@ -190,3 +190,5 @@ class PoincareBall(Manifold):
             manifolds.
         """
         return 2 / (1 - np.sum(point * point, axis=-1, keepdims=True))
+
+    to_tangent_space = projection

--- a/pymanopt/manifolds/hyperbolic.py
+++ b/pymanopt/manifolds/hyperbolic.py
@@ -29,19 +29,19 @@ class PoincareBall(Manifold):
     The norm here is understood as the Euclidean norm in the ambient space.
     """
 
-    def __init__(self, k: int, n: int = 1):
-        self._k = k
+    def __init__(self, n: int, *, k: int = 1):
         self._n = n
+        self._k = k
 
-        if k < 1:
-            raise ValueError(f"Need k >= 1. Value given was k = {k}")
         if n < 1:
             raise ValueError(f"Need n >= 1. Value given was n = {n}")
+        if k < 1:
+            raise ValueError(f"Need k >= 1. Value given was k = {k}")
 
-        if n == 1:
-            name = f"Poincare ball B({k})"
-        elif n >= 2:
-            name = f"Poincare ball B({k})^{n}"
+        if k == 1:
+            name = f"Poincare ball B({n})"
+        elif k >= 2:
+            name = f"Poincare ball B({n})^{k}"
 
         dimension = k * n
         super().__init__(name, dimension)
@@ -63,12 +63,12 @@ class PoincareBall(Manifold):
         )
 
     def random_point(self):
-        if self._n == 1:
-            array = np.random.normal(size=self._k)
+        if self._k == 1:
+            array = np.random.normal(size=self._n)
         else:
-            array = np.random.normal(size=(self._k, self._n))
+            array = np.random.normal(size=(self._n, self._k))
         norms = np.linalg.norm(array, axis=0)
-        radiuses = np.random.uniform(size=self._n) ** (1.0 / self._k)
+        radiuses = np.random.uniform(size=self._k) ** (1.0 / self._n)
         return radiuses * array / norms
 
     def random_tangent_vector(self, point):

--- a/pymanopt/manifolds/hyperbolic.py
+++ b/pymanopt/manifolds/hyperbolic.py
@@ -1,0 +1,149 @@
+import numpy as np
+
+from pymanopt.manifolds.manifold import Manifold
+
+
+class PoincareBall(Manifold):
+    """
+    Factory class for the Poincare ball model of hyperbolic geometry.
+    An instance represents the Cartesian product of n (defaults to 1)
+    Poincare balls of dimension k.
+    Elements are represented as matrices of size k x n, or arrays of
+    size k if n = 1.
+
+    The Poincare ball is embedded in R^k and is a Riemannian manifold,
+    but it is not an embedded Riemannian submanifold.
+    At every point x, the tangent space at x is R^k since the manifold
+    is open.
+
+    The metric is conformal to the Euclidean one (angles are preserved),
+    and it is given at every point x by
+        <u, v>_x = lambda_x^2 <u, v>,
+    where lambda_x = 2 / (1 - norm{x}^2) is the conformal factor.
+    This induces the following distance between any two points x and y:
+        dist(x, y) = acosh(
+            1 + 2 norm{x - y}^2 / (1 - norm{x}^2) / (1 - norm{y}^2)
+        ).
+    """
+
+    def __init__(self, k: int, n: int = 1):
+        self._k = k
+        self._n = n
+
+        if k < 1:
+            raise ValueError("Need k >= 1. Value supplied was k = %d." % k)
+        if n < 1:
+            raise ValueError("Need n >= 1. Value supplied was n = %d." % n)
+
+        if n == 1:
+            name = "Poincare ball B({:d})".format(k)
+        elif n >= 2:
+            name = "Product Poincare ball B({:d})^{:d}".format(k, n)
+
+        dimension = k * n
+        super().__init__(name, dimension)
+
+    @property
+    def typicaldist(self):
+        return self.dim / 8
+
+    # The metric in the Poincare ball is conformal to the Euclidean one.
+    def conformal_factor(self, X):
+        return 2 / (1 - np.sum(X * X, axis=0))
+
+    def inner(self, X, G, H):
+        factors = np.square(self.conformal_factor(X))
+        return np.sum(G * H * factors)
+
+    # Identity map since the tangent space is the ambient space.
+    def proj(self, X, G):
+        return G
+
+    def norm(self, X, G):
+        return np.sqrt(self.inner(X, G, G))
+
+    # Generates points sampled uniformly at random in the unit ball.
+    # In high dimension (large k), sampled points are very likely to
+    # be close to the boundary because of the curse of dimensionality.
+    def rand(self):
+        if self._n == 1:
+            N = np.random.randn(self._k)
+        else:
+            N = np.random.randn(self._k, self._n)
+        norms = np.linalg.norm(N, axis=0)
+        radiuses = np.random.rand(self._n) ** (1.0 / self._k)
+        return radiuses * N / norms
+
+    def randvec(self, X):
+        return np.random.randn(*np.shape(X))
+
+    def zerovec(self, X):
+        return np.zeros(np.shape(X))
+
+    # Geodesic distance.
+    def dist(self, X, Y):
+        norms2_X = np.sum(X * X, axis=0)
+        norms2_Y = np.sum(Y * Y, axis=0)
+        difference = X - Y
+        norms2_difference = np.sum(difference * difference, axis=0)
+
+        columns_dist = np.arccosh(
+            1 + 2 * norms2_difference / ((1 - norms2_X) * (1 - norms2_Y))
+        )
+        return np.sqrt(np.sum(np.square(columns_dist)))
+
+    # The hyperbolic metric tensor is conformal to the Euclidean one,
+    # so the Euclidean gradient is simply rescaled.
+    def egrad2rgrad(self, X, G):
+        factors = np.square(1 / self.conformal_factor(X))
+        return G * factors
+
+    # Derived from the Koszul formula.
+    def ehess2rhess(self, X, G, H, U):
+        lambda_x = self.conformal_factor(X)
+        return (
+            np.sum(G * X, axis=0) * U
+            - np.sum(X * U, axis=0) * G
+            - np.sum(G * U, axis=0) * X
+            + H / lambda_x
+        ) / lambda_x
+
+    # Exponential map is cheap so use it as a retraction.
+    def retr(self, X, G):
+        return self.exp(X, G)
+
+    # Special non-associative and non-commutative operation
+    # which is closed in the Poincare ball.
+    # Performed column-wise here.
+    def mobius_addition(self, X, Y):
+        scalar_product = np.sum(X * Y, axis=0)
+        norm2X = np.sum(X * X, axis=0)
+        norm2Y = np.sum(Y * Y, axis=0)
+
+        return (X * (1 + 2 * scalar_product + norm2Y) + Y * (1 - norm2X)) / (
+            1 + 2 * scalar_product + norm2X * norm2Y
+        )
+
+    def exp(self, X, U):
+        norm_U = np.linalg.norm(U, axis=0)
+        # Handle the case where U is null.
+        W = U * np.divide(
+            np.tanh(norm_U / (1 - np.sum(X * X, axis=0))),
+            norm_U,
+            out=np.zeros_like(U),
+            where=norm_U != 0,
+        )
+        return self.mobius_addition(X, W)
+
+    def log(self, X, Y):
+        W = self.mobius_addition(-X, Y)
+        norm_W = np.linalg.norm(W, axis=0)
+        return (1 - np.sum(X * X, axis=0)) * np.arctanh(norm_W) * W / norm_W
+
+    # I don't have a nice expression for this.
+    # To be completed in the future.
+    def transp(self, X1, X2, G):
+        raise NotImplementedError
+
+    def pairmean(self, X, Y):
+        return self.exp(X, self.log(X, Y) / 2)

--- a/tests/manifolds/test_hyperbolic.py
+++ b/tests/manifolds/test_hyperbolic.py
@@ -15,72 +15,71 @@ class TestSinglePoincareBallManifold(TestCase):
     def test_dim(self):
         assert self.man.dim == self.k
 
-    # def test_typicaldist(self):
-    #     pass
-
     def test_conformal_factor(self):
-        x = self.man.rand() / 2
+        x = self.man.random_point() / 2
         np_testing.assert_allclose(
             1 - 2 / self.man.conformal_factor(x), la.norm(x) ** 2
         )
 
-    def test_inner(self):
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
-        v = self.man.randvec(x)
+    def test_inner_product(self):
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
+        v = self.man.random_tangent_vector(x)
         np_testing.assert_allclose(
             (2 / (1 - la.norm(x) ** 2)) ** 2 * np.inner(u, v),
-            self.man.inner(x, u, v),
+            self.man.inner_product(x, u, v),
         )
 
         # test that angles are preserved
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
-        v = self.man.randvec(x)
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
+        v = self.man.random_tangent_vector(x)
         cos_eangle = np.sum(u * v) / la.norm(u) / la.norm(v)
         cos_rangle = (
-            self.man.inner(x, u, v) / self.man.norm(x, u) / self.man.norm(x, v)
+            self.man.inner_product(x, u, v)
+            / self.man.norm(x, u)
+            / self.man.norm(x, v)
         )
         np_testing.assert_allclose(cos_rangle, cos_eangle)
 
     def test_proj(self):
-        x = self.man.rand()
-        u = self.man.randvec(x)
-        np_testing.assert_allclose(u, self.man.proj(x, u))
+        x = self.man.random_point()
+        u = self.man.random_tangent_vector(x)
+        np_testing.assert_allclose(u, self.man.projection(x, u))
 
     def test_norm(self):
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
 
         np_testing.assert_allclose(
             2 / (1 - la.norm(x) ** 2) * la.norm(u), self.man.norm(x, u)
         )
 
-    def test_rand(self):
+    def test_random_point(self):
         # Just make sure that things generated are on the manifold and that
         # if you generate two they are not equal.
-        x = self.man.rand()
+        x = self.man.random_point()
         np_testing.assert_array_less(la.norm(x), 1)
-        y = self.man.rand()
+        y = self.man.random_point()
         assert not np.array_equal(x, y)
 
-    def test_randvec(self):
+    def test_random_tangent_vector(self):
         # Just make sure that things generated are in the tangent space and
         # that if you generate two they are not equal.
-        x = self.man.rand()
-        u = self.man.randvec(x)
-        v = self.man.randvec(x)
+        x = self.man.random_point()
+        u = self.man.random_tangent_vector(x)
+        v = self.man.random_tangent_vector(x)
 
         assert not np.array_equal(u, v)
 
-    def test_zerovec(self):
-        x = self.man.rand()
-        u = self.man.zerovec(x)
+    def test_zero_vector(self):
+        x = self.man.random_point()
+        u = self.man.zero_vector(x)
         np_testing.assert_allclose(la.norm(u), 0)
 
     def test_dist(self):
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
         correct_dist = np.arccosh(
             1
             + 2
@@ -96,42 +95,39 @@ class TestSinglePoincareBallManifold(TestCase):
     # def test_ehess2rhess(self):
     #     pass
 
-    def test_retr(self):
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
-        y = self.man.retr(x, u)
+    def test_retraction(self):
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
+        y = self.man.retraction(x, u)
         assert la.norm(y) <= 1 + 1e-10
 
     def test_mobius_addition(self):
         # test if Mobius addition is closed in the Poincare ball
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
         z = self.man.mobius_addition(x, y)
         # The norm of z may be slightly more than one because of
         # round-off errors.
         assert la.norm(z) <= 1 + 1e-10
 
     def test_exp_log_inverse(self):
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
         explog = self.man.exp(x, self.man.log(x, y))
         np_testing.assert_allclose(y, explog)
 
     def test_log_exp_inverse(self):
-        x = self.man.rand() / 2
+        x = self.man.random_point() / 2
         # If u is too big its exponential will have norm 1 because of
         # numerical approximations
-        u = self.man.randvec(x) / self.man.dim
+        u = self.man.random_tangent_vector(x) / self.man.dim
         logexp = self.man.log(x, self.man.exp(x, u))
         np_testing.assert_allclose(u, logexp)
 
-    # def test_transp(self):
-    #     pass
-
-    def test_pairmean(self):
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
-        z = self.man.pairmean(x, y)
+    def test_pair_mean(self):
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
+        z = self.man.pair_mean(x, y)
         np_testing.assert_allclose(self.man.dist(x, z), self.man.dist(y, z))
 
 
@@ -144,36 +140,33 @@ class TestMultiplePoincareBallManifold(TestCase):
     def test_dim(self):
         assert self.man.dim == self.k * self.n
 
-    # def test_typicaldist(self):
-    #     pass
-
     def test_conformal_factor(self):
-        x = self.man.rand() / 2
+        x = self.man.random_point() / 2
         np_testing.assert_allclose(
             1 - 2 / self.man.conformal_factor(x), la.norm(x, axis=0) ** 2
         )
 
-    def test_inner(self):
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
-        v = self.man.randvec(x)
+    def test_inner_product(self):
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
+        v = self.man.random_tangent_vector(x)
         np_testing.assert_allclose(
             np.sum(
                 (2 / (1 - la.norm(x, axis=0) ** 2)) ** 2
                 * np.sum(u * v, axis=0)
             ),
-            self.man.inner(x, u, v),
+            self.man.inner_product(x, u, v),
         )
 
     def test_proj(self):
-        x = self.man.rand()
-        u = self.man.randvec(x)
-        np_testing.assert_allclose(u, self.man.proj(x, u))
+        x = self.man.random_point()
+        u = self.man.random_tangent_vector(x)
+        np_testing.assert_allclose(u, self.man.projection(x, u))
 
     def test_norm(self):
         # Divide by 2 to avoid round-off errors.
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
 
         np_testing.assert_allclose(
             np.sum(
@@ -183,31 +176,31 @@ class TestMultiplePoincareBallManifold(TestCase):
             self.man.norm(x, u) ** 2,
         )
 
-    def test_rand(self):
+    def test_random_point(self):
         # Just make sure that things generated are on the manifold and that
         # if you generate two they are not equal.
-        x = self.man.rand()
+        x = self.man.random_point()
         np_testing.assert_array_less(la.norm(x, axis=0), 1)
-        y = self.man.rand()
+        y = self.man.random_point()
         assert not np.array_equal(x, y)
 
-    def test_randvec(self):
+    def test_random_tangent_vector(self):
         # Just make sure that things generated are in the tangent space and
         # that if you generate two they are not equal.
-        x = self.man.rand()
-        u = self.man.randvec(x)
-        v = self.man.randvec(x)
+        x = self.man.random_point()
+        u = self.man.random_tangent_vector(x)
+        v = self.man.random_tangent_vector(x)
 
         assert not np.array_equal(u, v)
 
-    def test_zerovec(self):
-        x = self.man.rand()
-        u = self.man.zerovec(x)
+    def test_zero_vector(self):
+        x = self.man.random_point()
+        u = self.man.zero_vector(x)
         np_testing.assert_allclose(la.norm(u), 0)
 
     def test_dist(self):
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
         correct_dist = np.sum(
             np.arccosh(
                 1
@@ -226,40 +219,37 @@ class TestMultiplePoincareBallManifold(TestCase):
     # def test_ehess2rhess(self):
     #     pass
 
-    def test_retr(self):
-        x = self.man.rand() / 2
-        u = self.man.randvec(x)
-        y = self.man.retr(x, u)
+    def test_retraction(self):
+        x = self.man.random_point() / 2
+        u = self.man.random_tangent_vector(x)
+        y = self.man.retraction(x, u)
         np_testing.assert_array_less(la.norm(y, axis=0), 1 + 1e-10)
 
     def test_mobius_addition(self):
         # test if Mobius addition is closed in the Poincare ball
-        x = self.man.rand()
-        y = self.man.rand()
+        x = self.man.random_point()
+        y = self.man.random_point()
         z = self.man.mobius_addition(x, y)
         # The norm of z may be slightly more than one because of
         # round-off errors.
         np_testing.assert_array_less(la.norm(z, axis=0), 1 + 1e-10)
 
     def test_exp_log_inverse(self):
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
         explog = self.man.exp(x, self.man.log(x, y))
         np_testing.assert_allclose(y, explog)
 
     def test_log_exp_inverse(self):
-        x = self.man.rand() / 2
+        x = self.man.random_point() / 2
         # If u is too big its exponential will have norm 1 because of
         # numerical approximations
-        u = self.man.randvec(x) / self.man.dim
+        u = self.man.random_tangent_vector(x) / self.man.dim
         logexp = self.man.log(x, self.man.exp(x, u))
         np_testing.assert_allclose(u, logexp)
 
-    # def test_transp(self):
-    #     pass
-
-    def test_pairmean(self):
-        x = self.man.rand() / 2
-        y = self.man.rand() / 2
-        z = self.man.pairmean(x, y)
+    def test_pair_mean(self):
+        x = self.man.random_point() / 2
+        y = self.man.random_point() / 2
+        z = self.man.pair_mean(x, y)
         np_testing.assert_allclose(self.man.dist(x, z), self.man.dist(y, z))

--- a/tests/manifolds/test_hyperbolic.py
+++ b/tests/manifolds/test_hyperbolic.py
@@ -1,0 +1,265 @@
+import autograd.numpy as np
+from numpy import linalg as la
+from numpy import testing as np_testing
+
+from pymanopt.manifolds import PoincareBall
+
+from .._test import TestCase
+
+
+class TestSinglePoincareBallManifold(TestCase):
+    def setUp(self):
+        self.k = 50
+        self.man = PoincareBall(self.k)
+
+    def test_dim(self):
+        assert self.man.dim == self.k
+
+    # def test_typicaldist(self):
+    #     pass
+
+    def test_conformal_factor(self):
+        x = self.man.rand() / 2
+        np_testing.assert_allclose(
+            1 - 2 / self.man.conformal_factor(x), la.norm(x) ** 2
+        )
+
+    def test_inner(self):
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+        v = self.man.randvec(x)
+        np_testing.assert_allclose(
+            (2 / (1 - la.norm(x) ** 2)) ** 2 * np.inner(u, v),
+            self.man.inner(x, u, v),
+        )
+
+        # test that angles are preserved
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+        v = self.man.randvec(x)
+        cos_eangle = np.sum(u * v) / la.norm(u) / la.norm(v)
+        cos_rangle = (
+            self.man.inner(x, u, v) / self.man.norm(x, u) / self.man.norm(x, v)
+        )
+        np_testing.assert_allclose(cos_rangle, cos_eangle)
+
+    def test_proj(self):
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        np_testing.assert_allclose(u, self.man.proj(x, u))
+
+    def test_norm(self):
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+
+        np_testing.assert_allclose(
+            2 / (1 - la.norm(x) ** 2) * la.norm(u), self.man.norm(x, u)
+        )
+
+    def test_rand(self):
+        # Just make sure that things generated are on the manifold and that
+        # if you generate two they are not equal.
+        x = self.man.rand()
+        np_testing.assert_array_less(la.norm(x), 1)
+        y = self.man.rand()
+        assert not np.array_equal(x, y)
+
+    def test_randvec(self):
+        # Just make sure that things generated are in the tangent space and
+        # that if you generate two they are not equal.
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        v = self.man.randvec(x)
+
+        assert not np.array_equal(u, v)
+
+    def test_zerovec(self):
+        x = self.man.rand()
+        u = self.man.zerovec(x)
+        np_testing.assert_allclose(la.norm(u), 0)
+
+    def test_dist(self):
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        correct_dist = np.arccosh(
+            1
+            + 2
+            * la.norm(x - y) ** 2
+            / (1 - la.norm(x) ** 2)
+            / (1 - la.norm(y) ** 2)
+        )
+        np_testing.assert_allclose(correct_dist, self.man.dist(x, y))
+
+    # def test_egrad2rgrad(self):
+    #     pass
+
+    # def test_ehess2rhess(self):
+    #     pass
+
+    def test_retr(self):
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+        y = self.man.retr(x, u)
+        assert la.norm(y) <= 1 + 1e-10
+
+    def test_mobius_addition(self):
+        # test if Mobius addition is closed in the Poincare ball
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        z = self.man.mobius_addition(x, y)
+        # The norm of z may be slightly more than one because of
+        # round-off errors.
+        assert la.norm(z) <= 1 + 1e-10
+
+    def test_exp_log_inverse(self):
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        explog = self.man.exp(x, self.man.log(x, y))
+        np_testing.assert_allclose(y, explog)
+
+    def test_log_exp_inverse(self):
+        x = self.man.rand() / 2
+        # If u is too big its exponential will have norm 1 because of
+        # numerical approximations
+        u = self.man.randvec(x) / self.man.dim
+        logexp = self.man.log(x, self.man.exp(x, u))
+        np_testing.assert_allclose(u, logexp)
+
+    # def test_transp(self):
+    #     pass
+
+    def test_pairmean(self):
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        z = self.man.pairmean(x, y)
+        np_testing.assert_allclose(self.man.dist(x, z), self.man.dist(y, z))
+
+
+class TestMultiplePoincareBallManifold(TestCase):
+    def setUp(self):
+        self.k = 50
+        self.n = 20
+        self.man = PoincareBall(self.k, self.n)
+
+    def test_dim(self):
+        assert self.man.dim == self.k * self.n
+
+    # def test_typicaldist(self):
+    #     pass
+
+    def test_conformal_factor(self):
+        x = self.man.rand() / 2
+        np_testing.assert_allclose(
+            1 - 2 / self.man.conformal_factor(x), la.norm(x, axis=0) ** 2
+        )
+
+    def test_inner(self):
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+        v = self.man.randvec(x)
+        np_testing.assert_allclose(
+            np.sum(
+                (2 / (1 - la.norm(x, axis=0) ** 2)) ** 2
+                * np.sum(u * v, axis=0)
+            ),
+            self.man.inner(x, u, v),
+        )
+
+    def test_proj(self):
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        np_testing.assert_allclose(u, self.man.proj(x, u))
+
+    def test_norm(self):
+        # Divide by 2 to avoid round-off errors.
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+
+        np_testing.assert_allclose(
+            np.sum(
+                (2 / (1 - la.norm(x, axis=0) ** 2)) ** 2
+                * np.sum(u * u, axis=0)
+            ),
+            self.man.norm(x, u) ** 2,
+        )
+
+    def test_rand(self):
+        # Just make sure that things generated are on the manifold and that
+        # if you generate two they are not equal.
+        x = self.man.rand()
+        np_testing.assert_array_less(la.norm(x, axis=0), 1)
+        y = self.man.rand()
+        assert not np.array_equal(x, y)
+
+    def test_randvec(self):
+        # Just make sure that things generated are in the tangent space and
+        # that if you generate two they are not equal.
+        x = self.man.rand()
+        u = self.man.randvec(x)
+        v = self.man.randvec(x)
+
+        assert not np.array_equal(u, v)
+
+    def test_zerovec(self):
+        x = self.man.rand()
+        u = self.man.zerovec(x)
+        np_testing.assert_allclose(la.norm(u), 0)
+
+    def test_dist(self):
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        correct_dist = np.sum(
+            np.arccosh(
+                1
+                + 2
+                * la.norm(x - y, axis=0) ** 2
+                / (1 - la.norm(x, axis=0) ** 2)
+                / (1 - la.norm(y, axis=0) ** 2)
+            )
+            ** 2
+        )
+        np_testing.assert_allclose(correct_dist, self.man.dist(x, y) ** 2)
+
+    # def test_egrad2rgrad(self):
+    #     pass
+
+    # def test_ehess2rhess(self):
+    #     pass
+
+    def test_retr(self):
+        x = self.man.rand() / 2
+        u = self.man.randvec(x)
+        y = self.man.retr(x, u)
+        np_testing.assert_array_less(la.norm(y, axis=0), 1 + 1e-10)
+
+    def test_mobius_addition(self):
+        # test if Mobius addition is closed in the Poincare ball
+        x = self.man.rand()
+        y = self.man.rand()
+        z = self.man.mobius_addition(x, y)
+        # The norm of z may be slightly more than one because of
+        # round-off errors.
+        np_testing.assert_array_less(la.norm(z, axis=0), 1 + 1e-10)
+
+    def test_exp_log_inverse(self):
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        explog = self.man.exp(x, self.man.log(x, y))
+        np_testing.assert_allclose(y, explog)
+
+    def test_log_exp_inverse(self):
+        x = self.man.rand() / 2
+        # If u is too big its exponential will have norm 1 because of
+        # numerical approximations
+        u = self.man.randvec(x) / self.man.dim
+        logexp = self.man.log(x, self.man.exp(x, u))
+        np_testing.assert_allclose(u, logexp)
+
+    # def test_transp(self):
+    #     pass
+
+    def test_pairmean(self):
+        x = self.man.rand() / 2
+        y = self.man.rand() / 2
+        z = self.man.pairmean(x, y)
+        np_testing.assert_allclose(self.man.dist(x, z), self.man.dist(y, z))

--- a/tests/manifolds/test_hyperbolic.py
+++ b/tests/manifolds/test_hyperbolic.py
@@ -30,7 +30,7 @@ class TestSinglePoincareBallManifold(TestCase):
             self.man.inner_product(x, u, v),
         )
 
-        # test that angles are preserved
+        # Test that angles are preserved.
         x = self.man.random_point() / 2
         u = self.man.random_tangent_vector(x)
         v = self.man.random_tangent_vector(x)
@@ -41,6 +41,11 @@ class TestSinglePoincareBallManifold(TestCase):
             / self.man.norm(x, v)
         )
         np_testing.assert_allclose(cos_rangle, cos_eangle)
+
+        # Test symmetry.
+        np_testing.assert_allclose(
+            self.man.inner_product(x, u, v), self.man.inner_product(x, v, u)
+        )
 
     def test_proj(self):
         x = self.man.random_point()
@@ -89,11 +94,27 @@ class TestSinglePoincareBallManifold(TestCase):
         )
         np_testing.assert_allclose(correct_dist, self.man.dist(x, y))
 
-    # def test_egrad2rgrad(self):
-    #     pass
+    def test_euclidean_to_riemannian_gradient(self):
+        # For now just test whether the method returns an array of the correct
+        # shape.
+        point = self.man.random_point()
+        euclidean_gradient = np.random.normal(size=point.shape)
+        riemannian_gradient = self.man.euclidean_to_riemannian_gradient(
+            point, euclidean_gradient
+        )
+        assert euclidean_gradient.shape == riemannian_gradient.shape
 
-    # def test_ehess2rhess(self):
-    #     pass
+    def test_euclidean_to_riemannian_hessian(self):
+        # For now just test whether the method returns an array of the correct
+        # shape.
+        point = self.man.random_point()
+        euclidean_gradient = np.random.normal(size=point.shape)
+        euclidean_hessian = np.random.normal(size=point.shape)
+        tangent_vector = self.man.random_tangent_vector(point)
+        riemannian_hessian = self.man.euclidean_to_riemannian_hessian(
+            point, euclidean_gradient, euclidean_hessian, tangent_vector
+        )
+        assert euclidean_hessian.shape == riemannian_hessian.shape
 
     def test_retraction(self):
         x = self.man.random_point() / 2
@@ -143,7 +164,8 @@ class TestMultiplePoincareBallManifold(TestCase):
     def test_conformal_factor(self):
         x = self.man.random_point() / 2
         np_testing.assert_allclose(
-            1 - 2 / self.man.conformal_factor(x), la.norm(x, axis=0) ** 2
+            1 - 2 / self.man.conformal_factor(x),
+            la.norm(x, axis=-1, keepdims=True) ** 2,
         )
 
     def test_inner_product(self):
@@ -152,10 +174,15 @@ class TestMultiplePoincareBallManifold(TestCase):
         v = self.man.random_tangent_vector(x)
         np_testing.assert_allclose(
             np.sum(
-                (2 / (1 - la.norm(x, axis=0) ** 2)) ** 2
-                * np.sum(u * v, axis=0)
+                (2 / (1 - la.norm(x, axis=-1) ** 2)) ** 2
+                * np.sum(u * v, axis=-1)
             ),
             self.man.inner_product(x, u, v),
+        )
+
+        # Test symmetry.
+        np_testing.assert_allclose(
+            self.man.inner_product(x, u, v), self.man.inner_product(x, v, u)
         )
 
     def test_proj(self):
@@ -170,8 +197,8 @@ class TestMultiplePoincareBallManifold(TestCase):
 
         np_testing.assert_allclose(
             np.sum(
-                (2 / (1 - la.norm(x, axis=0) ** 2)) ** 2
-                * np.sum(u * u, axis=0)
+                (2 / (1 - la.norm(x, axis=-1) ** 2)) ** 2
+                * np.sum(u * u, axis=-1)
             ),
             self.man.norm(x, u) ** 2,
         )
@@ -180,7 +207,7 @@ class TestMultiplePoincareBallManifold(TestCase):
         # Just make sure that things generated are on the manifold and that
         # if you generate two they are not equal.
         x = self.man.random_point()
-        np_testing.assert_array_less(la.norm(x, axis=0), 1)
+        np_testing.assert_array_less(la.norm(x, axis=-1), 1)
         y = self.man.random_point()
         assert not np.array_equal(x, y)
 
@@ -205,25 +232,41 @@ class TestMultiplePoincareBallManifold(TestCase):
             np.arccosh(
                 1
                 + 2
-                * la.norm(x - y, axis=0) ** 2
-                / (1 - la.norm(x, axis=0) ** 2)
-                / (1 - la.norm(y, axis=0) ** 2)
+                * la.norm(x - y, axis=-1) ** 2
+                / (1 - la.norm(x, axis=-1) ** 2)
+                / (1 - la.norm(y, axis=-1) ** 2)
             )
             ** 2
         )
         np_testing.assert_allclose(correct_dist, self.man.dist(x, y) ** 2)
 
-    # def test_egrad2rgrad(self):
-    #     pass
+    def test_euclidean_to_riemannian_gradient(self):
+        # For now just test whether the method returns an array of the correct
+        # shape.
+        point = self.man.random_point()
+        euclidean_gradient = np.random.normal(size=point.shape)
+        riemannian_gradient = self.man.euclidean_to_riemannian_gradient(
+            point, euclidean_gradient
+        )
+        assert euclidean_gradient.shape == riemannian_gradient.shape
 
-    # def test_ehess2rhess(self):
-    #     pass
+    def test_euclidean_to_riemannian_hessian(self):
+        # For now just test whether the method returns an array of the correct
+        # shape.
+        point = self.man.random_point()
+        euclidean_gradient = np.random.normal(size=point.shape)
+        euclidean_hessian = np.random.normal(size=point.shape)
+        tangent_vector = self.man.random_tangent_vector(point)
+        riemannian_hessian = self.man.euclidean_to_riemannian_hessian(
+            point, euclidean_gradient, euclidean_hessian, tangent_vector
+        )
+        assert euclidean_hessian.shape == riemannian_hessian.shape
 
     def test_retraction(self):
         x = self.man.random_point() / 2
         u = self.man.random_tangent_vector(x)
         y = self.man.retraction(x, u)
-        np_testing.assert_array_less(la.norm(y, axis=0), 1 + 1e-10)
+        np_testing.assert_array_less(la.norm(y, axis=-1), 1 + 1e-10)
 
     def test_mobius_addition(self):
         # test if Mobius addition is closed in the Poincare ball
@@ -232,7 +275,7 @@ class TestMultiplePoincareBallManifold(TestCase):
         z = self.man.mobius_addition(x, y)
         # The norm of z may be slightly more than one because of
         # round-off errors.
-        np_testing.assert_array_less(la.norm(z, axis=0), 1 + 1e-10)
+        np_testing.assert_array_less(la.norm(z, axis=-1), 1 + 1e-10)
 
     def test_exp_log_inverse(self):
         x = self.man.random_point() / 2

--- a/tests/manifolds/test_hyperbolic.py
+++ b/tests/manifolds/test_hyperbolic.py
@@ -9,11 +9,11 @@ from .._test import TestCase
 
 class TestSinglePoincareBallManifold(TestCase):
     def setUp(self):
-        self.k = 50
-        self.man = PoincareBall(self.k)
+        self.n = 50
+        self.man = PoincareBall(self.n)
 
     def test_dim(self):
-        assert self.man.dim == self.k
+        assert self.man.dim == self.n
 
     def test_conformal_factor(self):
         x = self.man.random_point() / 2
@@ -133,9 +133,9 @@ class TestSinglePoincareBallManifold(TestCase):
 
 class TestMultiplePoincareBallManifold(TestCase):
     def setUp(self):
-        self.k = 50
-        self.n = 20
-        self.man = PoincareBall(self.k, self.n)
+        self.n = 50
+        self.k = 20
+        self.man = PoincareBall(self.n, k=self.k)
 
     def test_dim(self):
         assert self.man.dim == self.k * self.n


### PR DESCRIPTION
This PR builds on top of #123 to add the Poincare ball model to pymanopt. Notable changes are:
- The PR updates the API and naming convention of the class, including the meaning of the constructor arguments `n` and `k`.
- Points on the product manifold of Poincare balls are now represented as arrays of shape `(k, n)` where `k` denotes the number of Poincare balls, i.e., the first dimension indexes the element of the product. This is our convention for product manifolds followed throughout the toolbox.
- The class docstring was updated to be more in line with other manifold classes, including the use of proper math typesetting.