### PR TITLE
Clean up PSD fixed-rank (complex) manifold

### DIFF
--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -4,7 +4,7 @@ import scipy.linalg
 from pymanopt.manifolds.manifold import Manifold, RetrAsExpMixin
 
 
-class _PSDFixedRank(Manifold, RetrAsExpMixin):
+class _PSDFixedRank(Manifold):
     def __init__(self, n, k, name, dimension):
         self._n = n
         self._k = k
@@ -38,8 +38,10 @@ class _PSDFixedRank(Manifold, RetrAsExpMixin):
     ):
         return self.projection(point, euclidean_hessian)
 
-    def retraction(self, point, tangent_vector):
+    def exp(self, point, tangent_vector):
         return point + tangent_vector
+
+    retraction = exp
 
     def random_point(self):
         return np.random.normal(size=(self._n, self._k))

--- a/pymanopt/manifolds/psd.py
+++ b/pymanopt/manifolds/psd.py
@@ -16,15 +16,20 @@ class _PSDFixedRank(Manifold):
 
     def inner_product(self, point, tangent_vector_a, tangent_vector_b):
         return np.tensordot(
-            tangent_vector_a, tangent_vector_b, axes=tangent_vector_a.ndim
-        )
+            tangent_vector_a.conj(),
+            tangent_vector_b,
+            axes=tangent_vector_a.ndim,
+        ).real
+
+    def dist(self, point_a, point_b):
+        return self.norm(point_a, self.log(point_a, point_b))
 
     def norm(self, point, tangent_vector):
         return np.linalg.norm(tangent_vector)
 
     def projection(self, point, vector):
-        YtY = point.T @ point
-        AS = point.T @ vector - vector.T @ point
+        YtY = point.T.conj() @ point
+        AS = point.T.conj() @ vector - vector.T.conj() @ point
         Omega = scipy.linalg.solve_continuous_lyapunov(YtY, AS)
         return vector - point @ Omega
 
@@ -43,19 +48,23 @@ class _PSDFixedRank(Manifold):
 
     retraction = exp
 
+    def log(self, point_a, point_b):
+        u, _, vh = np.linalg.svd(point_b.T.conj() @ point_a)
+        return point_b @ u @ vh - point_a
+
     def random_point(self):
         return np.random.normal(size=(self._n, self._k))
 
     def random_tangent_vector(self, point):
         random_vector = self.random_point()
         tangent_vector = self.projection(point, random_vector)
-        return self._normalize(tangent_vector)
+        return tangent_vector / self.norm(point, tangent_vector)
 
     def transport(self, point_a, point_b, tangent_vector_a):
         return self.projection(point_b, tangent_vector_a)
 
     def _normalize(self, array):
-        return array / self.norm(None, array)
+        return array / np.linalg.norm(array)
 
     def zero_vector(self, point):
         return np.zeros((self._n, self._k))
@@ -146,27 +155,10 @@ class PSDFixedRankComplex(_PSDFixedRank):
         dimension = 2 * k * n - k * k
         super().__init__(n, k, name, dimension)
 
-    def inner_product(self, point, tangent_vector_a, tangent_vector_b):
-        return (
-            2
-            * np.tensordot(
-                tangent_vector_a, tangent_vector_b, axes=tangent_vector_a.ndim
-            ).real
-        )
-
-    def norm(self, point, tangent_vector):
-        return np.sqrt(
-            self.inner_product(point, tangent_vector, tangent_vector)
-        )
-
-    def dist(self, point_a, point_b):
-        s, _, d = np.linalg.svd(point_b.T.conj() @ point_a)
-        e = point_a - point_b @ s @ d
-        return self.inner_product(None, e, e) / 2
-
     def random_point(self):
-        rand_ = super().rand
-        return rand_() + 1j * rand_()
+        return np.random.normal(
+            size=(self._n, self._k)
+        ) + 1j * np.random.normal(size=(self._n, self._k))
 
 
 class Elliptope(Manifold, RetrAsExpMixin):

--- a/tests/manifolds/test_psd_fixedrank.py
+++ b/tests/manifolds/test_psd_fixedrank.py
@@ -1,3 +1,6 @@
+import numpy.testing as np_testing
+import scipy.stats
+
 from pymanopt.manifolds import PSDFixedRank
 
 from ._manifold_tests import ManifoldTestCase
@@ -5,9 +8,9 @@ from ._manifold_tests import ManifoldTestCase
 
 class TestPSDFixedRankManifold(ManifoldTestCase):
     def setUp(self):
-        n = 50
-        k = 10
-        self.manifold = PSDFixedRank(n, k)
+        self.n = 50
+        self.k = 10
+        self.manifold = PSDFixedRank(self.n, self.k)
 
         super().setUp()
 
@@ -15,7 +18,11 @@ class TestPSDFixedRankManifold(ManifoldTestCase):
 
     # def test_typical_dist(self):
 
-    # def test_dist(self):
+    def test_dist(self):
+        point_a = self.manifold.random_point()
+        Q = scipy.stats.ortho_group.rvs(self.k)
+        point_b = point_a @ Q
+        np_testing.assert_almost_equal(self.manifold.dist(point_a, point_b), 0)
 
     # def test_inner_product(self):
 
@@ -36,19 +43,19 @@ class TestPSDFixedRankManifold(ManifoldTestCase):
 
     # def test_transport(self):
 
-    # def test_exp_log_inverse(self):
-    # s = self.manifold
-    # X = s.random_point()
-    # U = s.random_tangent_vector(X)
-    # Uexplog = s.exp(X, s.log(X, U))
-    # np_testing.assert_array_almost_equal(U, Uexplog)
+    def test_exp_log_inverse(self):
+        s = self.manifold
+        X = s.random_point()
+        Y = s.random_point()
+        Yexplog = s.exp(X, s.log(X, Y))
+        np_testing.assert_almost_equal(s.dist(Y, Yexplog), 0)
 
-    # def test_log_exp_inverse(self):
-    # s = self.manifold
-    # X = s.random_point()
-    # U = s.random_tangent_vector(X)
-    # Ulogexp = s.log(X, s.exp(X, U))
-    # np_testing.assert_array_almost_equal(U, Ulogexp)
+    def test_log_exp_inverse(self):
+        s = self.manifold
+        X = s.random_point()
+        U = s.random_tangent_vector(X)
+        Ulogexp = s.log(X, s.exp(X, U))
+        np_testing.assert_almost_equal(s.norm(X, U - Ulogexp), 0)
 
     # def test_pair_mean(self):
     # s = self.manifold

--- a/tests/manifolds/test_psd_fixedrank_complex.py
+++ b/tests/manifolds/test_psd_fixedrank_complex.py
@@ -1,3 +1,6 @@
+import numpy.testing as np_testing
+import scipy.stats
+
 from pymanopt.manifolds import PSDFixedRankComplex
 
 from ._manifold_tests import ManifoldTestCase
@@ -5,9 +8,9 @@ from ._manifold_tests import ManifoldTestCase
 
 class TestPSDFixedRankComplexManifold(ManifoldTestCase):
     def setUp(self):
-        n = 50
-        k = 10
-        self.manifold = PSDFixedRankComplex(n, k)
+        self.n = 50
+        self.k = 10
+        self.manifold = PSDFixedRankComplex(self.n, self.k)
 
         super().setUp()
 
@@ -15,7 +18,11 @@ class TestPSDFixedRankComplexManifold(ManifoldTestCase):
 
     # def test_typical_dist(self):
 
-    # def test_dist(self):
+    def test_dist(self):
+        point_a = self.manifold.random_point()
+        U = scipy.stats.unitary_group.rvs(self.k)
+        point_b = point_a @ U
+        np_testing.assert_almost_equal(self.manifold.dist(point_a, point_b), 0)
 
     # def test_inner_product(self):
 
@@ -35,19 +42,19 @@ class TestPSDFixedRankComplexManifold(ManifoldTestCase):
 
     # def test_transport(self):
 
-    # def test_exp_log_inverse(self):
-    # s = self.manifold
-    # X = s.random_point()
-    # U = s.random_tangent_vector(X)
-    # Uexplog = s.exp(X, s.log(X, U))
-    # np_testing.assert_array_almost_equal(U, Uexplog)
+    def test_exp_log_inverse(self):
+        s = self.manifold
+        X = s.random_point()
+        Y = s.random_point()
+        Yexplog = s.exp(X, s.log(X, Y))
+        np_testing.assert_almost_equal(s.dist(Y, Yexplog), 0)
 
-    # def test_log_exp_inverse(self):
-    # s = self.manifold
-    # X = s.random_point()
-    # U = s.random_tangent_vector(X)
-    # Ulogexp = s.log(X, s.exp(X, U))
-    # np_testing.assert_array_almost_equal(U, Ulogexp)
+    def test_log_exp_inverse(self):
+        s = self.manifold
+        X = s.random_point()
+        U = s.random_tangent_vector(X)
+        Ulogexp = s.log(X, s.exp(X, U))
+        np_testing.assert_almost_equal(s.norm(X, U - Ulogexp), 0)
 
     # def test_pair_mean(self):
     # s = self.manifold


### PR DESCRIPTION
This PR fixes various issues/bugs in the `PSDFixedRank*` manifolds:
- Fix `inner_product` and `projection` of `PSDFixedRankComplex` by generalizing methods of shared base class for complex input.
- The exponential map on `PSDFixedRank(Complex)` can be implemented as a simple matrix addition. Use `exp` as `retraction` since it's trivial/cheap to compute.
- Generalize logarithmic map for both manifolds and as a result the distance map.
- Fix `random_point` method of `PSDFixedRankComplex` which was still using the old `rand()` API.
- Add unit tests for `dist`, `exp` and `log`.