### PR TITLE
Switch to forward-over-reverse mode hvp for autograd backend

### DIFF
--- a/examples/low_rank_matrix_approximation.py
+++ b/examples/low_rank_matrix_approximation.py
@@ -19,7 +19,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
         @pymanopt.function.autograd(manifold)
         def cost(u, s, vt):
             X = u @ np.diag(s) @ vt
-            return np.linalg.norm(X - matrix) ** 2
+            return np.sum((X - matrix) ** 2)
 
     elif backend == "numpy":
 

--- a/examples/low_rank_psd_matrix_approximation.py
+++ b/examples/low_rank_psd_matrix_approximation.py
@@ -18,7 +18,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
 
         @pymanopt.function.autograd(manifold)
         def cost(Y):
-            return np.linalg.norm(Y @ Y.T - matrix, "fro") ** 2
+            return np.sum((Y @ Y.T - matrix) ** 2)
 
     elif backend == "numpy":
 

--- a/examples/multiple_linear_regression.py
+++ b/examples/multiple_linear_regression.py
@@ -18,8 +18,7 @@ def create_cost_and_derivates(manifold, samples, targets, backend):
 
         @pymanopt.function.autograd(manifold)
         def cost(weights):
-            # Use autograd's linalg.norm wrapper.
-            return np.linalg.norm(targets - samples @ weights) ** 2
+            return np.sum((targets - samples @ weights) ** 2)
 
     elif backend == "numpy":
 

--- a/examples/pca.py
+++ b/examples/pca.py
@@ -18,7 +18,7 @@ def create_cost_and_derivates(manifold, samples, backend):
 
         @pymanopt.function.autograd(manifold)
         def cost(w):
-            return np.linalg.norm(samples - samples @ w @ w.T) ** 2
+            return np.sum((samples - samples @ w @ w.T) ** 2)
 
     elif backend == "numpy":
 

--- a/examples/rank_k_correlation_matrix_approximation.py
+++ b/examples/rank_k_correlation_matrix_approximation.py
@@ -18,7 +18,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
 
         @pymanopt.function.autograd(manifold)
         def cost(X):
-            return 0.25 * np.linalg.norm(X.T @ X - matrix) ** 2
+            return 0.25 * np.sum((X.T @ X - matrix) ** 2)
 
     elif backend == "numpy":
 

--- a/tests/test_problem_backend_interface.py
+++ b/tests/test_problem_backend_interface.py
@@ -18,7 +18,7 @@ class TestProblemBackendInterface(TestCase):
 
         @pymanopt.function.autograd(self.manifold)
         def cost(u, s, vt, x):
-            return np.linalg.norm(((u * s) @ vt - A) @ x) ** 2
+            return np.sum((((u * s) @ vt - A) @ x) ** 2)
 
         self.cost = cost
         self.gradient = self.cost.get_gradient_operator()


### PR DESCRIPTION
This (experimental) PR replaces autograd's hvp implementation with a version based on forward-over-reverse mode autodiff (see https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html?highlight=hvp#hessian-vector-products-using-both-forward-and-reverse-mode). This should generally be more efficient that our handrolled implementation that manually computes the gradient of the directional derivative.

Unfortunately, when development of autograd ceased, there was no JVP support for `numpy.linalg.norm` available, which we use in a few places. Some examples and test cases therefore had to be updated to support this change. I'm currently debating whether or not this limitation is worth it as it likely extends to more primitives than `numpy.linalg.norm`.