### PR TITLE
Add parameters to generate random SPD matrices

### DIFF
--- a/pymanopt/manifolds/positive_definite.py
+++ b/pymanopt/manifolds/positive_definite.py
@@ -109,7 +109,7 @@ class SymmetricPositiveDefinite(RiemannianSubmanifold):
         # Generate eigenvalues from a uniform distribution.
         d = np.random.uniform(low=low, high=high, size=(self._k, self._n, 1))
 
-        # Generate an orthogonal matrix from a normal distribution..
+        # Generate an orthogonal matrix from a normal distribution.
         q, _ = multiqr(
             np.random.normal(loc=loc, scale=scale, size=(self._n, self._n))
         )

--- a/pymanopt/manifolds/positive_definite.py
+++ b/pymanopt/manifolds/positive_definite.py
@@ -84,12 +84,37 @@ class SymmetricPositiveDefinite(RiemannianSubmanifold):
             self.inner_product(point, tangent_vector, tangent_vector)
         )
 
-    def random_point(self):
-        # Generate eigenvalues between 1 and 2.
-        d = 1.0 + np.random.uniform(size=(self._k, self._n, 1))
+    def random_point(self, *, low=1.0, high=2.0, loc=0.0, scale=1.0):
+        """Returns a random point on the manifold.
 
-        # Generate an orthogonal matrix.
-        q, _ = multiqr(np.random.normal(size=(self._n, self._n)))
+        Generate eigenvalues from a uniform distribution between lower and
+        upper bounds, generate an orthogonal matrix applying a QR decomposition
+        on a random matrix drawn from a normal distribution, and apply
+        conjugation.
+
+        Args:
+            low: Lower boundary of uniform distribution for eigenvalues.
+            high: Upper boundary of uniform distribution for eigenvalues.
+            loc: Mean of normal distribution for random matrix.
+            scale: Standard deviation of normal distribution for random matrix.
+
+        Returns:
+            A randomly chosen point on the manifold.
+        """
+        if low <= 0.0:
+            raise ValueError("Lower bound must be strictly positive")
+        if high <= low:
+            raise ValueError("Upper bound must be superior to lower bound")
+
+        # Generate eigenvalues from a uniform distribution.
+        d = np.random.uniform(low=low, high=high, size=(self._k, self._n, 1))
+
+        # Generate an orthogonal matrix from a normal distribution..
+        q, _ = multiqr(
+            np.random.normal(loc=loc, scale=scale, size=(self._n, self._n))
+        )
+
+        # Apply conjugation.
         point = q @ (d * multitransp(q))
         if self._k == 1:
             return point[0]

--- a/tests/manifolds/test_symmetric_positive_definite.py
+++ b/tests/manifolds/test_symmetric_positive_definite.py
@@ -44,6 +44,15 @@ class TestSingleSymmetricPositiveDefiniteManifold(ManifoldTestCase):
         w = np.linalg.eigvalsh(x)
         assert (w > [0]).all()
 
+        # Check use of all parameters
+        manifold.random_point(low=5.0, high=10.0, loc=2.0, scale=5.0)
+
+        with self.assertRaises(ValueError):
+            manifold.random_point(low=-1)
+
+        with self.assertRaises(ValueError):
+            manifold.random_point(low=2, high=1)
+
     def test_dist(self):
         manifold = self.manifold
         x = manifold.random_point()


### PR DESCRIPTION
This PR adds parameters to `random_point()`, in order to have more flexibility when generating random SPD matrices. 
Default values give the same behavior as before.