### PR TITLE
Convert tangent vectors to correct format for hvp calls

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,10 +1,10 @@
 # TODO/Roadmap
 
-## 1.1.x:
+## 2.0.x:
   - Add 'check_hessian' diagnostic function to add automatic tests for
     `euclidean_to_riemannian_hessian'
 
-## 1.2.x:
+## 2.1.x:
   - For Riemannian submanifolds of Euclidean space, it is acceptable to
     transport simply by orthogonal projection of the tangent vector translated
     in the ambient space. For this, 'RiemannianSubmanifold' would require a
@@ -20,7 +20,7 @@
   - Add callback mechanism to allow for custom termination criteria
   - Add support for complex manifolds to autodiff backends
 
-## 2.0.x:
+## 3.0.x:
   - Raise an exception if dimension of 'SphereSubspaceIntersection' manifold is
     0
   - Add pep8-naming (requires breaking public API to fix all errors)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,24 +98,26 @@ katex_autorender_path = (
 )
 # TODO(nkoep): Move this macro generation to its own module.
 latex_macros = r"""
-    \def \manM   {\mathcal{M}}
-    \def \R      {\mathbb{R}}
-    \def \C      {\mathbb{C}}
-    \def \O      {\mathrm{O}}
-    \def \SO     {\mathrm{SO}}
-    \def \U      {\mathrm{U}}
-    \def \E      {\mathcal{E}}
-    \def \St     {\mathrm{St}}
-    \def \Id     {\mathrm{Id}}
-    \def \set    #1{\{#1\}}
-    \def \inner  #2{\langle #1, #2 \rangle}
-    \def \opt    #1{#1^\star}
-    \def \sphere {\mathcal{S}}
-    \def \transp #1{#1^\top}
-    \def \conj   #1{#1^*}
-    \def \norm   #1{\|#1\|}
-    \def \abs    #1{|#1|}
-    \def \parens #1{\left(#1\right)}
+    \def \manM    {\mathcal{M}}
+    \def \R       {\mathbb{R}}
+    \def \C       {\mathbb{C}}
+    \def \O       {\mathrm{O}}
+    \def \SO      {\mathrm{SO}}
+    \def \U       {\mathrm{U}}
+    \def \E       {\mathcal{E}}
+    \def \Skew    {\mathrm{Skew}}
+    \def \St      {\mathrm{St}}
+    \def \Id      {\mathrm{Id}}
+    \def \set     #1{\{#1\}}
+    \def \inner   #2{\langle #1, #2 \rangle}
+    \def \opt     #1{#1^\star}
+    \def \sphere  {\mathcal{S}}
+    \def \transp  #1{#1^\top}
+    \def \conj    #1{#1^*}
+    \def \norm    #1{\|#1\|}
+    \def \abs     #1{|#1|}
+    \def \parens  #1{\left(#1\right)}
+    \def \tangent #1{\mathrm{T}_{#1}}
 """
 # Generate macros for boldface letters.
 latex_macros += "\n".join(
@@ -123,6 +125,7 @@ latex_macros += "\n".join(
         r"\def \vm{letter} {{\mathbf{{{letter}}}}}".format(letter=letter)
         for letter in string.ascii_lowercase + string.ascii_uppercase
     ]
+    + [r"\def \vmOmega {\mathbf{\Omega}}"]
 )
 katex_macros = katex.latex_defs_to_katex_macros(latex_macros)
 katex_options = (

--- a/pymanopt/manifolds/fixed_rank.py
+++ b/pymanopt/manifolds/fixed_rank.py
@@ -35,7 +35,8 @@ class FixedRankEmbedded(RiemannianSubmanifold):
     Tangent vectors are represented as tuples of the form ``(Up, M, Vp)``.
     The matrices ``Up`` (of size ``m x k``) and ``Vp`` (of size ``n x k``) obey
     the conditions ``np.allclose(Up.T @ U, 0)`` and ``np.allclose(Vp.T @ V,
-    0)``. The matrix ``M`` (of size ``k x k``) is arbitrary.
+    0)``.
+    The matrix ``M`` (of size ``k x k``) is arbitrary.
     Such a structure corresponds to the tangent vector ``Z = u @ M @ vt + Up @
     vt + u * Vp.T`` in the ambient space of ``m x n`` matrices at a point ``(u,
     s, vt)``.

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -362,14 +362,12 @@ class Manifold(metaclass=abc.ABCMeta):
         """Convert tangent vector to ambient space representation.
 
         Certain manifolds represent tangent vectors in a format that is more
-        conducive for internal calculations than their representation in the
+        convenient for numerical calculations than their representation in the
         ambient space.
         Euclidean Hessian operators generally expect tangent vectors in their
         ambient space representation though.
-        This method allows switching between these two representations and is
-        mainly useful when implementing custom `euclidean_hessian` functions
-        that are passed to :class:`pymanopt.core.problem.Problem`.
-        Note that for most manifolds, ``embedding`` is simply the identity map.
+        This method allows switching between the two possible representations,
+        For most manifolds, ``embedding`` is simply the identity map.
 
         Args:
             point: A point on the manifold.

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -95,7 +95,7 @@ class Manifold(metaclass=abc.ABCMeta):
             return sum(self.point_layout)
         return self.point_layout
 
-    # Manifold properties that subclasses can define
+    # Manifold properties that subclasses can define.
 
     @property
     def typical_dist(self):
@@ -347,8 +347,8 @@ class Manifold(metaclass=abc.ABCMeta):
 
         This method guarantees that ``vector`` is indeed a tangent vector
         at ``point`` on the manifold.
-        Typically this simply corresponds to ``proj(point, vector)`` but may
-        differ for certain manifolds.
+        Typically this simply corresponds to a call to meth:`projection` but
+        may differ for certain manifolds.
 
         Args:
             point: A point on the manifold.
@@ -357,6 +357,33 @@ class Manifold(metaclass=abc.ABCMeta):
         Returns:
             The tangent vector at ``point`` closest to ``vector``.
         """
+
+    def embedding(self, point, tangent_vector):
+        """Convert tangent vector to ambient space representation.
+
+        Certain manifolds represent tangent vectors in a format that is more
+        conducive for internal calculations than their representation in the
+        ambient space.
+        Euclidean Hessian operators generally expect tangent vectors in their
+        ambient space representation though.
+        This method allows switching between these two representations and is
+        mainly useful when implementing custom `euclidean_hessian` functions
+        that are passed to :class:`pymanopt.core.problem.Problem`.
+        Note that for most manifolds, ``embedding`` is simply the identity map.
+
+        Args:
+            point: A point on the manifold.
+            tangent_vector: A tangent vector in the internal representation of
+                the manifold.
+
+        Returns:
+            The same tangent vector in the ambient space representation.
+
+        Note:
+            This method is called internally when Hessian operators are
+            generated automatically by one of the autodiff backends.
+        """
+        return tangent_vector
 
 
 class RiemannianSubmanifold(Manifold, metaclass=abc.ABCMeta):

--- a/pymanopt/manifolds/manifold.py
+++ b/pymanopt/manifolds/manifold.py
@@ -380,8 +380,10 @@ class Manifold(metaclass=abc.ABCMeta):
             The same tangent vector in the ambient space representation.
 
         Note:
-            This method is called internally when Hessian operators are
-            generated automatically by one of the autodiff backends.
+            This method is mainly needed internally by the
+            :class:`pymanopt.core.problem.Problem` class in order to convert
+            tangent vectors to the representation expected by user-given or
+            autodiff-generated Euclidean Hessian operators.
         """
         return tangent_vector
 

--- a/pymanopt/manifolds/special_orthogonal_group.py
+++ b/pymanopt/manifolds/special_orthogonal_group.py
@@ -29,8 +29,13 @@ class SpecialOrthogonalGroup(RiemannianSubmanifold):
     :math:`(\R^{n \times n})^k`.
     As such :math:`\SO(n)^k` forms a Riemannian submanifold.
 
-    Tangent vectors are represented in the Lie algebra of skew-symmetric
-    matrices of the same shape as points on the manifold.
+    The tangent space :math:`\tangent{\vmQ}\SO(n)` at a point :math:`\vmQ` is
+    given by :math:`\tangent{\vmQ}\SO(n) = \set{\vmQ \vmOmega \in \R^{n \times
+    n} \mid \vmOmega = -\transp{\vmOmega}} = \vmQ \Skew(n)`, where
+    :math:`\Skew(n)` denotes the set of skew-symmetric matrices.
+    This corresponds to the Lie algebra of :math:`\SO(n)`, a fact which is used
+    here to conveniently represent tangent vectors numerically by their
+    skew-symmetric factor.
     The method :meth:`embedding` can be used to transform a tangent vector from
     its Lie algebra representation to the embedding space representation.
 


### PR DESCRIPTION
I realized that the behavior I described in https://github.com/pymanopt/pymanopt/pull/199 regarding the 2nd order approximation of cost functions defined on the special orthogonal group was due to the fact that tangent vectors are represented in the Lie algebra of skew-symmetric matrices. In the tests, the Euclidean Hessian function created by the autodiff backend was therefore receiving tangent vectors in the incorrect format.

While I'm aware that in manopt this conversion is expected to be performed by the user by calling `tangent2ambient` inside of `ehess` functions, we need to inject such conversion calls automatically in order to support automatic differentiation. Technically we could do this conversion only when the (Euclidean) Hessian operator was generated by an autodiff backend, and let users call `manifold.embedding(point, tangent_vector)` manually when providing `euclidean_hessian` functions as in manopt. For simplicity, however, I believe it is better to convert tangent vectors to the natural representation automatically for user-defined `euclidean_hessian` functions.

Note that the bug fix in this PR is technically a backward incompatible change which means we should bump the major version of pymanopt when we want to release a new version.