### PR TITLE
[WIP] use backend everywhere i/o only for autodiff

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,3 +5,6 @@ Sebastian Weichwald (sweichwald)
 2018-11 additions to the maintainers team:
 Nicolas Boumal (NicolasBoumal)
 Bamdev Mishra (bamdevm)
+
+2023-06 additions to the maintainers team:
+Antoine Collas (antoinecollas)


### PR DESCRIPTION
Hi!

Status quo: One needs to decorate the cost function to indicate which autodiff backend ought to be used by pymanopt to obtain gradient/hessian of the cost function. Pymanopt solvers, however, are implemented in numpy and rely on casting from/to numpy arrays.

Idea: Use the backend throughout to avoid moving back and forth between backend and numpy. This requires adapting the solvers to rely on the backend to compute SVDs thinly adding corresponding functionality to the backends.