### PR TITLE
chore(build): drop `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-exclude .*.yaml TODO.md
-prune .github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,12 @@ write_to = "src/pymanopt/_version.py"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-exclude = ["tests*"]
+exclude = [
+  "tests*",
+  ".*.yaml",
+  "TODO.md",
+  ".github*",
+]
 
 [tool.black]
 include = '\.py$'


### PR DESCRIPTION
This PR aims to build on top of the work of #236, by configuring packaging metadata within `pyproject.toml`. Changes proposed by PR can be summarized as follows:

* delete: `MANIFEST.in`
* feat: amend `exclude` key of `[tool.setuptools.packages.find]` to include the list from `MANIFEST.in`

### Testing
The changes were verified by building using `python -m build` and inspecting the generated wheel.

Request for Review: @nkoep 