### PR TITLE
Fix error produced by `jax.config` and complex valued dot product

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up python 3.7
+      - name: Set up python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/build_release_package.yml
+++ b/.github/workflows/build_release_package.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up python 3.7
+      - name: Set up python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
+          # - "3.8"
+          # - "3.9"
           - "3.10"
     steps:
       - name: Checkout

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-          # - "3.8"
-          # - "3.9"
+          - "3.8"
+          - "3.9"
           - "3.10"
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "BSD 3-Clause License"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = [
   "manifolds",
   "optimization",

--- a/src/pymanopt/autodiff/backends/_jax.py
+++ b/src/pymanopt/autodiff/backends/_jax.py
@@ -9,7 +9,12 @@ except ImportError:
     jax = None
 else:
     import jax.numpy as jnp
-    from jax import config
+
+    # for backward compatibility with older versions of jax
+    try:
+        from jax import config
+    except ImportError:
+        from jax.config import config
 
     config.update("jax_enable_x64", True)
 

--- a/src/pymanopt/autodiff/backends/_jax.py
+++ b/src/pymanopt/autodiff/backends/_jax.py
@@ -9,7 +9,7 @@ except ImportError:
     jax = None
 else:
     import jax.numpy as jnp
-    from jax.config import config
+    from jax import config
 
     config.update("jax_enable_x64", True)
 

--- a/src/pymanopt/autodiff/backends/_pytorch.py
+++ b/src/pymanopt/autodiff/backends/_pytorch.py
@@ -85,7 +85,7 @@ class PyTorchBackend(Backend):
             for gradient, vector in zip(gradients, vectors):
                 dot_product += torch.tensordot(
                     gradient.conj(), vector, dims=gradient.ndim
-                )
+                ).real
             dot_product.backward()
             return self._sanitize_gradients(arguments)
 


### PR DESCRIPTION
This PR fixes several problems with `jax` to make the tests work again:
- fixes the `jax.config` problem, see issue #260
- raises the minimum version of python from 3.7 to 3.8 since `jax` dropped its support, see https://github.com/google/jax/pull/13443

This PR is important since other libraries are waiting for `pymanopt` to have `jax` working again, see https://github.com/PythonOT/POT/issues/609

This PR also fixes the hessian_vector_product function when gradient and/or direction are complex-valued. Now PyTorch raises an error if the scalar is not real.
