### PR TITLE
Allow scipy>=1.13

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,9 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.x"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 dependencies = [
   "numpy>=1.16.0",
-  "scipy>=1.0,<1.10",
+  "scipy>=1.0,!=1.10.*,!=1.11.*,!=1.12.*",
 ]
 [project.urls]
 homepage = "https://pymanopt.org"


### PR DESCRIPTION
I looked into #269 a little more closely, and I found that the test suite passes with scipy 1.13, but not with 1.12.  I think this is due to the fact that 1.13 includes a fix for scipy/scipy#16792. 
 Given this, I adjusted the scipy dependency version specifier to allow <=1.9 or >=1.13.  (More specifically, I excluded versions 1.10, 1.11, and 1.12.)  This allows pymanopt to be successfully installed for python 3.12.

I also configured GitHub Actions to run the test suite on the most recent version of python, which should hopefully catch errors like this sooner in the future.
