### PR TITLE
Changed autograd import in autograd backend to match new autograd version

### DIFF
--- a/src/pymanopt/autodiff/backends/_autograd.py
+++ b/src/pymanopt/autodiff/backends/_autograd.py
@@ -2,7 +2,7 @@ import functools
 
 
 try:
-    import autograd
+    import autograd.differential_operators as autograd
 except ImportError:
     autograd = None
 else:


### PR DESCRIPTION
Using autograd version 1.6.2 (newest) there is an error calling "autograd.grad" in autodiff/backends/_autograd.py, because it is now "autograd.differential_operators.grad".
Changed the import from autograd to autograd.differential_operators, so that the grad calls are still valid.

I noticed this when using SteepestDescent for a Pymanopt problem.