### PR TITLE
Generalized Stiefel

### DIFF
--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -30,6 +30,8 @@ Bibliography
    379-402.
 .. [Mez2006] Mezzadri, Francesco. "How to generate random matrices from the
    classical compact groups." arXiv preprint math-ph/0609050 (2006).
+.. [SA2019] Sato, Hiroyuki, and Aihara, Kensuke. "Cholesky QR-based retraction on the
+   generalized Stiefel manifold." Computational Optimization and Applications 72 (2019): 293-308
 .. [SH2015] Sra, Suvrit, and Reshad Hosseini. "Conic geometric optimization on
    the manifold of positive definite matrices." SIAM Journal on Optimization
    25.1 (2015): 713-739.

--- a/docs/manifolds.rst
+++ b/docs/manifolds.rst
@@ -44,6 +44,11 @@ Stiefel Manifold
 
 .. automodule:: pymanopt.manifolds.stiefel
 
+Generalized Stiefel Manifold
+----------------------------
+
+.. automodule:: pymanopt.manifolds.generalized_stiefel
+
 Grassmann Manifold
 ------------------
 

--- a/src/pymanopt/manifolds/__init__.py
+++ b/src/pymanopt/manifolds/__init__.py
@@ -5,6 +5,7 @@ __all__ = [
     "Euclidean",
     "ComplexEuclidean",
     "FixedRankEmbedded",
+    "GeneralizedStiefel",
     "Grassmann",
     "HermitianPositiveDefinite",
     "SpecialHermitianPositiveDefinite",
@@ -28,6 +29,7 @@ __all__ = [
 from .complex_circle import ComplexCircle
 from .euclidean import ComplexEuclidean, Euclidean, SkewSymmetric, Symmetric
 from .fixed_rank import FixedRankEmbedded
+from .generalized_stiefel import GeneralizedStiefel
 from .grassmann import ComplexGrassmann, Grassmann
 from .group import SpecialOrthogonalGroup, UnitaryGroup
 from .hyperbolic import PoincareBall

--- a/src/pymanopt/manifolds/generalized_stiefel.py
+++ b/src/pymanopt/manifolds/generalized_stiefel.py
@@ -1,0 +1,141 @@
+import numpy as np
+import scipy
+
+from pymanopt.manifolds.manifold import Manifold
+
+
+class GeneralizedStiefel(Manifold):
+    r"""The Generalized Stiefel manifold.
+
+    The Generalized Stiefel manifold :math:`\St(n, p, B)` is the
+    manifold of orthonormal ``n x p`` matrices w.r.t. a symmetric
+    positive definite matrix :math:`\vmB\in\R^{n\times n}`.
+    A point :math:`\vmX \in \St(n, p, B)` therefore satisfies the condition
+    :math:`\transp{\vmX}\vmB\vmX = \Id_p`.
+    Points on the manifold are represented as arrays of shape ``(n, p)``.
+
+    Args:
+        n: The number of rows.
+        p: The number of columns.
+        B: A symmetric positive definite matrix
+        Binv: Inverse of B if known
+        retraction: The type of retraction to use.
+            Possible choices are ``qr`` and ``polar``.
+
+    Note:
+        The matrix :math:`\vmB` can be provided as a numpy array or
+        as a scipy sparse matrix.
+
+        The default retraction used here is a first-order one based on
+        the QR decomposition.
+        To switch to a second-order polar retraction, use
+        ``GeneralizedStiefel(n, p, B, retraction="polar")``.
+
+        Obtaining the Riemannian gradient from the Euclidean gradient requires
+        the inverse of :math:`\vmB`. If this is known the inverse can be provided
+        to speed up this operation.
+    """
+
+    def __init__(
+        self,
+        n: int,
+        p: int,
+        B: np.array,
+        *,
+        Binv: np.array = None,
+        retraction: str = "qr",
+    ):
+        self._n = n
+        self._p = p
+        self.B = B
+        self.Binv = Binv
+        # Check that n is greater than or equal to p
+        if n < p or p < 1:
+            raise ValueError(
+                f"Need n >= p >= 1. Values supplied were n = {n} and p = {p}"
+            )
+        name = f"Generalized Stiefel manifold St({n},{p},B)"
+        dimension = int((n * p - p * (p + 1) / 2))
+        super().__init__(name, dimension)
+        try:
+            self._retraction = getattr(self, f"_retraction_{retraction}")
+        except AttributeError:
+            raise ValueError(f"Invalid retraction type '{retraction}'")
+
+    @property
+    def typical_dist(self):
+        return np.sqrt(self._p)
+
+    def inner_product(self, point, tangent_vector_a, tangent_vector_b):
+        return np.vdot(tangent_vector_a, self.B @ tangent_vector_b)
+
+    def projection(self, point, vector):
+        return vector - point @ self.sym(point.T @ self.B @ vector)
+
+    def sym(self, A):
+        """Returns the symmetric part of A."""
+        return 0.5 * (A + A.T)
+
+    to_tangent_space = projection
+
+    def retraction(self, point, tangent_vector):
+        return self._retraction(point, tangent_vector)
+
+    def _retraction_qr(self, point, tangent_vector):
+        Y = point + tangent_vector
+        return self.gqf(Y)
+
+    def _retraction_polar(self, point, tangent_vector):
+        Y = point + tangent_vector
+        return self.guf(Y)
+
+    def norm(self, point, tangent_vector):
+        return np.sqrt(
+            self.inner_product(point, tangent_vector, tangent_vector)
+        )
+
+    def random_point(self):
+        if self._retraction == self._retraction_qr:
+            point = self.gqf(np.random.normal(size=(self._n, self._p)))
+        elif self._retraction == self._retraction_polar:
+            point = self.guf(np.random.normal(size=(self._n, self._p)))
+        return point
+
+    def random_tangent_vector(self, point):
+        vector = np.random.normal(size=point.shape)
+        vector = self.projection(point, vector)
+        return vector / np.linalg.norm(vector)
+
+    def transport(self, point_a, point_b, tangent_vector_a):
+        return self.projection(point_b, tangent_vector_a)
+
+    def euclidean_to_riemannian_gradient(self, point, euclidean_gradient):
+        if self.Binv is not None:
+            egrad_scaled = self.Binv @ euclidean_gradient
+        else:
+            egrad_scaled = scipy.linalg.solve(self.B, euclidean_gradient)
+        rgrad = egrad_scaled - point @ self.sym(point.T @ euclidean_gradient)
+        return rgrad
+
+    def zero_vector(self, point):
+        return np.zeros((self._n, self._p))
+
+    def guf(self, Y):
+        """Generalized polar decomposition."""
+        U, _, Vh = np.linalg.svd(Y, full_matrices=False)
+        ssquare, q = np.linalg.eig(U.T @ self.B @ U)
+        qsinv = q / np.sqrt(ssquare)
+        X = U @ (qsinv @ q.T @ Vh)
+        return X.real
+
+    def gqf(self, Y):
+        """Generalized QR decomposition.
+
+        See algorithm 3.1 in [SA2019]_
+        """
+        # Generalized QR decomposition
+        # Algorithm 3.1 in https://doi.org/10.1007/s10589-018-0046-7
+        R = scipy.linalg.cholesky(self.sym(Y.T @ self.B @ Y))
+        # R is upper triangular
+        X_T = scipy.linalg.solve_triangular(R.T, Y.T, lower=True)
+        return X_T.T

--- a/tests/manifolds/test_generalized_stiefel.py
+++ b/tests/manifolds/test_generalized_stiefel.py
@@ -1,0 +1,91 @@
+import autograd.numpy as np
+import pytest
+from numpy import testing as np_testing
+
+from pymanopt.manifolds import GeneralizedStiefel
+
+
+class TestGeneralizedStiefelManifold:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.m = m = 20
+        self.n = n = 2
+        A = np.random.rand(m, m)
+        B = np.dot(A, A.transpose())
+        self.B = B
+        self.manifold = GeneralizedStiefel(m, n, B)
+        self.manifold_polar = GeneralizedStiefel(m, n, B, retraction="polar")
+        self.projection = (
+            lambda x, u: u - x @ (x.T @ self.B @ u + u.T @ self.B.T @ x) / 2
+        )
+        self.sym = lambda A: 0.5 * (A + A.T)
+
+    def test_dim(self):
+        assert self.manifold.dim == 0.5 * self.n * (2 * self.m - self.n - 1)
+
+    def test_inner_product(self):
+        X = self.manifold.random_point()
+        A, B = np.random.normal(size=(2, self.m, self.n))
+        np_testing.assert_allclose(
+            np.trace(A.T @ self.B @ B), self.manifold.inner_product(X, A, B)
+        )
+
+    def test_projection(self):
+        # Construct a random point X on the manifold.
+        X = self.manifold.random_point()
+        # Construct a vector H in the ambient space.
+        H = np.random.normal(size=(self.m, self.n))
+        # Compare the projections.
+        Hproj = H - X @ (X.T @ self.B @ H + H.T @ self.B.T @ X) / 2
+        np_testing.assert_allclose(Hproj, self.manifold.projection(X, H))
+
+    @pytest.mark.parametrize(
+        "manifold_attribute", ["manifold", "manifold_polar"]
+    )
+    def test_random_point(self, manifold_attribute):
+        manifold = getattr(self, manifold_attribute)
+        # Just make sure that things generated are on the manifold and that
+        # if you generate two they are not equal.
+        X = manifold.random_point()
+        np_testing.assert_allclose(
+            X.T @ self.B @ X, np.eye(self.n), atol=1e-10
+        )
+        Y = manifold.random_point()
+        assert np.linalg.norm(X - Y) > 1e-6
+
+    def test_random_tangent_vector(self):
+        # Make sure things generated are in tangent space and if you generate
+        # two then they are not equal.
+        X = self.manifold.random_point()
+        U = self.manifold.random_tangent_vector(X)
+        np_testing.assert_allclose(
+            self.sym(X.T @ self.B @ U), np.zeros((self.n, self.n)), atol=1e-10
+        )
+        V = self.manifold.random_tangent_vector(X)
+        assert np.linalg.norm(U - V) > 1e-6
+
+    @pytest.mark.parametrize(
+        "manifold_attribute", ["manifold", "manifold_polar"]
+    )
+    def test_retraction(self, manifold_attribute):
+        manifold = getattr(self, manifold_attribute)
+
+        # Test that the result is on the manifold and that for small
+        # tangent vectors it has little effect.
+        x = manifold.random_point()
+        u = manifold.random_tangent_vector(x)
+        xretru = manifold.retraction(x, u)
+        np_testing.assert_allclose(
+            xretru.T @ self.B @ xretru, np.eye(self.n), atol=1e-10
+        )
+        u = u * 1e-6
+        xretru = manifold.retraction(x, u)
+        np_testing.assert_allclose(xretru, x + u)
+
+    def test_norm(self):
+        x = self.manifold.random_point()
+        u = self.manifold.random_tangent_vector(x)
+        np_testing.assert_almost_equal(
+            self.manifold.norm(x, u),
+            np.sqrt(np.sum(np.trace(u.T @ self.B @ u, axis1=-2, axis2=-1))),
+        )


### PR DESCRIPTION
Hi
This pull request adds the Generalised Stiefel manifold. It's heavily based on the manopt version [here](https://github.com/NicolasBoumal/manopt/blob/335d1bbaf8bb916f7a5a7adead6c87b171b093c0/manopt/manifolds/stiefel/stiefelgeneralizedfactory.m).
There's a few ways the matrix $\mathbf{B}$, can be provided (numpy array, scipy sparse matrix, scipy linear operator). Additionally, $\mathbf{B^{-1}}$ can be given, if known, to speed up the Euclidean to Riemannian gradient routine. Otherwise, the LU decomposition of $\mathbf{B}$ is computed on the first call to this function, which is then stored to speed up future linear systems solves.
Please let me know if there's anything more to add or change.
Best,
Calum

