### PR TITLE
Rework of `dtype`s

### DIFF
--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -45,7 +45,6 @@ class Backend(ABC):
     # Common attributes, properties and methods
     ##########################################################################
     _dtype: type
-    _dtype_precision: DTypePrecision
 
     @runtime_checkable  # to be able to check isinstance(x, bk.array_t)
     class array_t(Protocol):
@@ -144,6 +143,7 @@ class Backend(ABC):
         ...
 
     @property
+    @abstractmethod
     def dtype_precision(self) -> DTypePrecision:
         ...
 

--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 from functools import wraps
 from typing import (
     Callable,
@@ -14,7 +15,7 @@ import numpy as np
 import scipy.special
 
 
-__all__ = ["TupleOrList", "Backend", "DummyBackendSingleton"]
+__all__ = ["TupleOrList", "DTypePrecision", "Backend", "DummyBackendSingleton"]
 
 T = TypeVar("T")
 TupleOrList = Union[list[T], tuple[T, ...]]
@@ -30,6 +31,13 @@ def not_implemented(function):
     return inner
 
 
+class DTypePrecision(Enum):
+    """Enum for the dtype precision of the backend."""
+
+    SINGLE = 32
+    DOUBLE = 64
+
+
 class Backend(ABC):
     """Abstract base class defining the interface for autodiff backends."""
 
@@ -37,8 +45,9 @@ class Backend(ABC):
     # Common attributes, properties and methods
     ##########################################################################
     _dtype: type
+    _dtype_precision: DTypePrecision
 
-    @runtime_checkable
+    @runtime_checkable  # to be able to check isinstance(x, bk.array_t)
     class array_t(Protocol):
         """Array type used for static type checks.
 
@@ -132,6 +141,10 @@ class Backend(ABC):
     @property
     @abstractmethod
     def dtype(self) -> type:
+        ...
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
         ...
 
     @property

--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -699,6 +699,10 @@ class DummyBackend(Backend):
         ...
 
     @property
+    def dtype_precision(self):
+        ...
+
+    @property
     def is_dtype_real(self):
         ...
 

--- a/src/pymanopt/backends/jax_backend.py
+++ b/src/pymanopt/backends/jax_backend.py
@@ -49,11 +49,6 @@ class JaxBackend(Backend):
         ), f"dtype {dtype} is not supported"
         self._dtype = dtype
         self._random_key = jax.random.key(random_seed)
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if (dtype == jnp.float32 or dtype == jnp.complex64)
-            else DTypePrecision.DOUBLE
-        )
 
     def _gen_1_random_key(self):
         self._random_key, new_key = jax.random.split(self._random_key)
@@ -68,6 +63,14 @@ class JaxBackend(Backend):
     @property
     def dtype(self) -> jnp.dtype:
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == jnp.float32 or self.dtype == jnp.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/jax_backend.py
+++ b/src/pymanopt/backends/jax_backend.py
@@ -8,7 +8,7 @@ import jax.scipy as jscipy
 import numpy as np
 import scipy.linalg
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
@@ -41,8 +41,19 @@ class JaxBackend(Backend):
     _dtype: jnp.dtype
 
     def __init__(self, dtype=jnp.float64, random_seed: int = 42):
+        assert (
+            dtype == jnp.float32
+            or dtype == jnp.float64
+            or dtype == jnp.complex64
+            or dtype == jnp.complex128
+        ), f"dtype {dtype} is not supported"
         self._dtype = dtype
         self._random_key = jax.random.key(random_seed)
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if (dtype == jnp.float32 or dtype == jnp.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     def _gen_1_random_key(self):
         self._random_key, new_key = jax.random.split(self._random_key)
@@ -64,11 +75,11 @@ class JaxBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return jnp.array([1.0]).dtype
+        return jnp.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return jnp.array([1j]).dtype
+        return jnp.complex128
 
     def __repr__(self):
         return f"JaxBackend(dtype={self.dtype})"

--- a/src/pymanopt/backends/numpy_backend.py
+++ b/src/pymanopt/backends/numpy_backend.py
@@ -7,7 +7,7 @@ import packaging.version as pv
 import scipy
 import scipy.linalg
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 
 
 def _raise_not_implemented_error(*args, **kwargs):
@@ -35,6 +35,11 @@ class NumpyBackend(Backend):
             or dtype == np.complex128
         ), f"dtype {dtype} is not supported"
         self._dtype = dtype
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if (dtype == np.float32 or dtype == np.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def dtype(self):
@@ -46,11 +51,11 @@ class NumpyBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return np.array([1.0]).dtype
+        return np.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return np.array([1j]).dtype
+        return np.complex128
 
     def __repr__(self):
         return f"NumpyBackend(dtype={self.dtype})"

--- a/src/pymanopt/backends/numpy_backend.py
+++ b/src/pymanopt/backends/numpy_backend.py
@@ -35,15 +35,18 @@ class NumpyBackend(Backend):
             or dtype == np.complex128
         ), f"dtype {dtype} is not supported"
         self._dtype = dtype
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if (dtype == np.float32 or dtype == np.complex64)
-            else DTypePrecision.DOUBLE
-        )
 
     @property
     def dtype(self):
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == np.float32 or self.dtype == np.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -6,7 +6,7 @@ import scipy.linalg
 import torch
 from torch import autograd
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
@@ -47,6 +47,11 @@ class PytorchBackend(Backend):
             torch.complex128,
         }
         self._dtype = dtype
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if dtype in {torch.float32, torch.complex64}
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def dtype(self):
@@ -58,11 +63,11 @@ class PytorchBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return torch.tensor([1.0]).dtype
+        return torch.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return torch.tensor([1j]).dtype
+        return torch.complex128
 
     def to_real_backend(self) -> "PytorchBackend":
         if self.is_dtype_real:

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -47,15 +47,18 @@ class PytorchBackend(Backend):
             torch.complex128,
         }
         self._dtype = dtype
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if dtype in {torch.float32, torch.complex64}
-            else DTypePrecision.DOUBLE
-        )
 
     @property
     def dtype(self):
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == torch.float32 or self.dtype == torch.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/tensorflow_backend.py
+++ b/src/pymanopt/backends/tensorflow_backend.py
@@ -55,15 +55,18 @@ class TensorflowBackend(Backend):
             tf.complex128,
         }, f"dtype {dtype} is not supported"
         self._dtype = dtype
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if dtype in {tf.float32, tf.complex64}
-            else DTypePrecision.DOUBLE
-        )
 
     @property
     def dtype(self) -> tf.DType:
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == tf.float32 or self.dtype == tf.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/tensorflow_backend.py
+++ b/src/pymanopt/backends/tensorflow_backend.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy
 import tensorflow as tf
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
@@ -48,7 +48,18 @@ class TensorflowBackend(Backend):
     _dtype: tf.DType
 
     def __init__(self, dtype=tf.float64):
+        assert dtype in {
+            tf.float32,
+            tf.float64,
+            tf.complex64,
+            tf.complex128,
+        }, f"dtype {dtype} is not supported"
         self._dtype = dtype
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if dtype in {tf.float32, tf.complex64}
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def dtype(self) -> tf.DType:
@@ -60,11 +71,11 @@ class TensorflowBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return tf.constant([1.0]).dtype
+        return tf.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return tf.constant([1j]).dtype
+        return tf.complex128
 
     def __repr__(self):
         return f"TensorflowBackend(dtype={self.dtype})"

--- a/src/pymanopt/core/problem.py
+++ b/src/pymanopt/core/problem.py
@@ -43,30 +43,39 @@ class Problem:
     def __init__(
         self,
         manifold: Manifold,
-        cost: Function,
+        cost: Callable,
         *,
-        euclidean_gradient: Optional[Function] = None,
-        riemannian_gradient: Optional[Function] = None,
-        euclidean_hessian: Optional[Function] = None,
-        riemannian_hessian: Optional[Function] = None,
+        euclidean_gradient: Optional[Callable] = None,
+        riemannian_gradient: Optional[Callable] = None,
+        euclidean_hessian: Optional[Callable] = None,
+        riemannian_hessian: Optional[Callable] = None,
         preconditioner: Optional[Callable] = None,
     ):
         self.manifold = manifold
 
-        self._validate_function(cost, "cost")
         for function, name in (
+            (cost, "cost"),
             (euclidean_gradient, "euclidean_gradient"),
             (euclidean_hessian, "euclidean_hessian"),
             (riemannian_gradient, "riemannian_gradient"),
             (riemannian_hessian, "riemannian_hessian"),
         ):
             if function is not None:
-                self._validate_function(function, name)
+                assert isinstance(
+                    function, Callable
+                ), f"Function {name} must be callable"
 
+        # check backend compatibility between manifold and cost function
+        assert isinstance(cost, Callable)
         if manifold.has_dummy_backend():
-            manifold.set_compatible_backend(cost.backend)
+            if isinstance(cost, Function):
+                manifold.set_compatible_backend(cost.backend)
+            else:
+                raise ValueError(
+                    "Neither cost nor manifold have a specified backend."
+                )
         else:
-            self._validate_function_backend(cost, "cost", manifold)
+            cost = self._validate_function_backend(cost, "cost", manifold)
 
         self._original_cost = cost
         self._cost = self._wrap_function(cost)
@@ -83,7 +92,7 @@ class Problem:
             )
 
         if euclidean_gradient is not None:
-            self._validate_function_backend(
+            euclidean_gradient = self._validate_function_backend(
                 euclidean_gradient, "euclidean_gradient", manifold
             )
             euclidean_gradient = self._wrap_gradient_operator(
@@ -91,7 +100,7 @@ class Problem:
             )
         self._euclidean_gradient = euclidean_gradient
         if euclidean_hessian is not None:
-            self._validate_function_backend(
+            euclidean_hessian = self._validate_function_backend(
                 euclidean_hessian, "euclidean_hessian", manifold
             )
             euclidean_hessian = self._wrap_hessian_operator(
@@ -100,7 +109,7 @@ class Problem:
         self._euclidean_hessian = euclidean_hessian
 
         if riemannian_gradient is not None:
-            self._validate_function_backend(
+            riemannian_gradient = self._validate_function_backend(
                 riemannian_gradient, "riemannian_gradient", manifold
             )
             riemannian_gradient = self._wrap_gradient_operator(
@@ -108,7 +117,7 @@ class Problem:
             )
         self._riemannian_gradient = riemannian_gradient
         if riemannian_hessian is not None:
-            self._validate_function_backend(
+            riemannian_hessian = self._validate_function_backend(
                 riemannian_hessian, "rimeannian_hessian", manifold
             )
             riemannian_hessian = self._wrap_hessian_operator(
@@ -136,13 +145,19 @@ class Problem:
 
     @staticmethod
     def _validate_function_backend(
-        function: Function, name: str, manifold: Manifold
+        function: Callable, name: str, manifold: Manifold
     ):
-        assert manifold.is_backend_compatible(function.backend), (
-            f"Function '{name}' has a backend {function.backend} "
-            "which is not compatible with the manifold's backend"
-            f" {manifold.backend}."
-        )
+        if isinstance(function, Function):
+            assert manifold.is_backend_compatible(function.backend), (
+                f"Function '{name}' has a backend {function.backend} "
+                "which is not compatible with the manifold's backend"
+                f" {manifold.backend}."
+            )
+            return function
+        else:
+            return Function(
+                function=function, manifold=manifold, backend=manifold.backend
+            )
 
     def _flatten_arguments(self, arguments, signature):
         assert len(arguments) == len(signature)

--- a/src/pymanopt/core/problem.py
+++ b/src/pymanopt/core/problem.py
@@ -53,19 +53,23 @@ class Problem:
     ):
         self.manifold = manifold
 
+        self._validate_function(cost, "cost")
         for function, name in (
-            (cost, "cost"),
             (euclidean_gradient, "euclidean_gradient"),
             (euclidean_hessian, "euclidean_hessian"),
             (riemannian_gradient, "riemannian_gradient"),
             (riemannian_hessian, "riemannian_hessian"),
         ):
-            self._validate_function(function, name)
+            if function is not None:
+                self._validate_function(function, name)
 
         if manifold.has_dummy_backend():
-            manifold.set_backend_with_default_dtype(type(cost.backend))
+            manifold.set_compatible_backend(cost.backend)
         else:
-            assert manifold.is_backend_compatible(type(cost.backend))
+            self._validate_function_backend(cost, "cost", manifold)
+
+        self._original_cost = cost
+        self._cost = self._wrap_function(cost)
 
         if euclidean_gradient is not None and riemannian_gradient is not None:
             raise ValueError(
@@ -78,26 +82,35 @@ class Problem:
                 "provided, not both"
             )
 
-        self._original_cost = cost
-        self._cost = self._wrap_function(cost)
-
         if euclidean_gradient is not None:
+            self._validate_function_backend(
+                euclidean_gradient, "euclidean_gradient", manifold
+            )
             euclidean_gradient = self._wrap_gradient_operator(
                 euclidean_gradient
             )
         self._euclidean_gradient = euclidean_gradient
         if euclidean_hessian is not None:
+            self._validate_function_backend(
+                euclidean_hessian, "euclidean_hessian", manifold
+            )
             euclidean_hessian = self._wrap_hessian_operator(
                 euclidean_hessian, embed_tangent_vectors=True
             )
         self._euclidean_hessian = euclidean_hessian
 
         if riemannian_gradient is not None:
+            self._validate_function_backend(
+                riemannian_gradient, "riemannian_gradient", manifold
+            )
             riemannian_gradient = self._wrap_gradient_operator(
                 riemannian_gradient
             )
         self._riemannian_gradient = riemannian_gradient
         if riemannian_hessian is not None:
+            self._validate_function_backend(
+                riemannian_hessian, "rimeannian_hessian", manifold
+            )
             riemannian_hessian = self._wrap_hessian_operator(
                 riemannian_hessian
             )
@@ -117,10 +130,19 @@ class Problem:
 
     @staticmethod
     def _validate_function(function, name):
-        if function is not None and not isinstance(function, Function):
-            raise ValueError(
-                f"Function '{name}' must be decorated with a backend decorator"
-            )
+        assert isinstance(
+            function, Function
+        ), f"Function '{name}' must be decorated with a backend decorator."
+
+    @staticmethod
+    def _validate_function_backend(
+        function: Function, name: str, manifold: Manifold
+    ):
+        assert manifold.is_backend_compatible(function.backend), (
+            f"Function '{name}' has a backend {function.backend} "
+            "which is not compatible with the manifold's backend"
+            f" {manifold.backend}."
+        )
 
     def _flatten_arguments(self, arguments, signature):
         assert len(arguments) == len(signature)

--- a/src/pymanopt/function.py
+++ b/src/pymanopt/function.py
@@ -86,6 +86,8 @@ def decorator_factory(
             backend = (
                 backend_type(dtype=dtype)
                 if dtype is not None
+                # by default use float64, which is fine for a function it only
+                # uses autodiff methods (which do not depend on realness)
                 else backend_type()
             )
             return Function(function=cost, manifold=manifold, backend=backend)

--- a/src/pymanopt/function.py
+++ b/src/pymanopt/function.py
@@ -2,7 +2,7 @@ __all__ = ["Function", "autograd", "jax", "numpy", "pytorch", "tensorflow"]
 
 import inspect
 from importlib import import_module
-from typing import Any, Callable
+from typing import Any, Callable, Optional, Protocol
 
 from pymanopt.backends import Backend
 from pymanopt.manifolds.manifold import Manifold
@@ -52,11 +52,18 @@ def _only_one_true(*args):
     return sum(args) == 1
 
 
+class _ObjectiveFunctionDecorator(Protocol):
+    def __call__(
+        self, manifold: Manifold, dtype: Optional[Any] = None
+    ) -> Callable[[Callable[..., Any]], Function]:
+        ...
+
+
 def decorator_factory(
     module: str, backend_class: str
-) -> Callable[[Manifold], Callable[[Callable[..., Any]], Function]]:
+) -> _ObjectiveFunctionDecorator:
     def decorator(
-        manifold: Manifold,
+        manifold: Manifold, dtype: Optional[Any] = None
     ) -> Callable[[Callable[..., Any]], Function]:
         assert isinstance(manifold, Manifold)
 
@@ -70,12 +77,17 @@ def decorator_factory(
                 "Decorated function must only accept positional arguments "
                 "or a variable-length argument like *x"
             )
-            backend = getattr(
+            backend_type = getattr(
                 import_module(
                     f"pymanopt.backends.{module}",
                 ),
                 backend_class,
-            )()
+            )
+            backend = (
+                backend_type(dtype=dtype)
+                if dtype is not None
+                else backend_type()
+            )
             return Function(function=cost, manifold=manifold, backend=backend)
 
         return inner

--- a/src/pymanopt/manifolds/euclidean.py
+++ b/src/pymanopt/manifolds/euclidean.py
@@ -107,11 +107,6 @@ class Euclidean(_Euclidean):
         dimension = math.prod(shape)
         super().__init__(name, dimension, *shape, backend=backend)
 
-        @RiemannianSubmanifold.backend.setter
-        def _(self, backend: Backend):
-            assert backend.is_dtype_real()
-            super().backend = backend
-
 
 class ComplexEuclidean(_Euclidean):
     r"""Complex Euclidean manifold.
@@ -145,15 +140,8 @@ class ComplexEuclidean(_Euclidean):
         dimension = 2 * np.prod(shape)
         super().__init__(name, dimension, *shape, backend=backend)
 
-    @RiemannianSubmanifold.backend.setter
-    def _(self, backend: Backend):
-        assert not backend.is_dtype_real()
-        super().backend = backend
-
     def random_point(self):
-        return self.backend.random_randn(
-            *self._shape
-        ) + 1j * self.backend.random_randn(*self._shape)
+        return self.backend.random_randn(*self._shape)
 
     def zero_vector(self, point):
         return np.zeros(self._shape, dtype=complex)

--- a/src/pymanopt/manifolds/euclidean.py
+++ b/src/pymanopt/manifolds/euclidean.py
@@ -144,7 +144,7 @@ class ComplexEuclidean(_Euclidean):
         return self.backend.random_randn(*self._shape)
 
     def zero_vector(self, point):
-        return np.zeros(self._shape, dtype=complex)
+        return self.backend.zeros(self._shape)
 
 
 class Symmetric(_Euclidean):

--- a/src/pymanopt/manifolds/fixed_rank.py
+++ b/src/pymanopt/manifolds/fixed_rank.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from pymanopt.backends import Backend, DummyBackendSingleton
-from pymanopt.manifolds.manifold import Manifold, RiemannianSubmanifold
+from pymanopt.manifolds.manifold import RiemannianSubmanifold
 from pymanopt.manifolds.stiefel import Stiefel
 from pymanopt.tools import ArraySequenceMixin, return_as_class_instance
 
@@ -112,16 +112,10 @@ class FixedRankEmbedded(RiemannianSubmanifold):
         dimension = (m + n - k) * k
         super().__init__(name, dimension, point_layout=3, backend=backend)
 
-    @Manifold.backend.setter
-    def backend(self, backend: Backend):
-        self._backend = backend
-        self._stiefel_m.backend = backend
-        self._stiefel_n.backend = backend
-
-    def set_backend_with_default_dtype(self, backend_type: type):
-        super().set_backend_with_default_dtype(backend_type)
-        self._stiefel_m.set_backend_with_default_dtype(backend_type)
-        self._stiefel_n.set_backend_with_default_dtype(backend_type)
+    def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
+        self._stiefel_m.set_compatible_backend(other_backend)
+        self._stiefel_n.set_compatible_backend(other_backend)
 
     @property
     def typical_dist(self):

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -114,30 +114,27 @@ class Manifold(metaclass=abc.ABCMeta):
         """The numerics backend used by the manifold."""
         return self._backend
 
-    @backend.setter
-    def backend(self, backend: Backend):
-        self._backend = backend
-
     def has_dummy_backend(self) -> bool:
         return self.backend == DummyBackendSingleton
 
-    def set_backend_with_default_dtype(self, backend_type: type):
-        """Set the manifold's backend based on a default.
+    def set_compatible_backend(self, other_backend: Backend):
+        """Set the manifold's backend based on another backend.
 
-        This default depends on the provided backend type, the manifold's
-        :attr:`IS_COMPLEX` property and the default precision of the backend
-        for the corresponding dtype (e.g. for real numbers, NumPy defaults to
-        float64 whereas PyTorch defaults to float32).
+        It sets a backend with the same type (numpy, pytorch, etc.)
+        and dtype precision (single or double) and chooses real or complex
+        based on the manifold type.
         """
-        assert issubclass(backend_type, Backend)
-        self.backend = backend_type(
-            backend_type.DEFAULT_COMPLEX_DTYPE()
+        self.backend = (
+            other_backend.to_complex_backend()
             if self.IS_COMPLEX
-            else backend_type.DEFAULT_REAL_DTYPE()
+            else other_backend.to_real_backend()
         )
 
-    def is_backend_compatible(self, backend_type: type) -> bool:
-        return isinstance(self.backend, backend_type)
+    def is_backend_compatible(self, other_backend: Backend) -> bool:
+        return (
+            type(self.backend) is type(other_backend)
+            and self.backend.dtype_precision == other_backend.dtype_precision
+        )
 
     @property
     def num_values(self) -> int:

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -124,7 +124,7 @@ class Manifold(metaclass=abc.ABCMeta):
         and dtype precision (single or double) and chooses real or complex
         based on the manifold type.
         """
-        self.backend = (
+        self._backend = (
             other_backend.to_complex_backend()
             if self.IS_COMPLEX
             else other_backend.to_real_backend()

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -84,7 +84,7 @@ class Manifold(metaclass=abc.ABCMeta):
         self._name = name
         self._dimension = dimension
         self._point_layout = point_layout
-        self._backend = backend
+        self.set_compatible_backend(backend)
 
     def __str__(self):
         return self._name
@@ -129,6 +129,11 @@ class Manifold(metaclass=abc.ABCMeta):
             if self.IS_COMPLEX
             else other_backend.to_real_backend()
         )
+        if self._backend != other_backend:
+            warnings.warn(
+                f"Incompatible realness between manifold {self} and backend "
+                f"{other_backend}. Setting a compatible backend."
+            )
 
     def is_backend_compatible(self, other_backend: Backend) -> bool:
         return (

--- a/src/pymanopt/manifolds/product.py
+++ b/src/pymanopt/manifolds/product.py
@@ -1,5 +1,4 @@
 import functools
-import warnings
 from typing import Sequence
 
 import numpy as np
@@ -52,19 +51,17 @@ class Product(Manifold):
     def __init__(
         self,
         manifolds: Sequence[Manifold],
-        backend: Backend = DummyBackendSingleton,
     ):
         for manifold in manifolds:
             if isinstance(manifold, Product):
                 raise ValueError("Nested product manifolds are not supported")
 
-        # check all manifolds have the same backend type
-        # TODO: should we also enforce same precision? (32 vs 64)
-        first_type = type(manifolds[0].backend)
+        # check all manifolds have compatible backends
+        first_backend = manifolds[0].backend
         for manifold in manifolds[1:]:
-            if type(manifold.backend) is not first_type:
+            if not manifold.is_backend_compatible(first_backend):
                 raise ValueError(
-                    "All manifolds in a product must have the same backend type"
+                    "All manifolds in a product must have compatible backends."
                 )
 
         self.manifolds = tuple(manifolds)
@@ -73,19 +70,11 @@ class Product(Manifold):
 
         dimension = np.sum([manifold.dim for manifold in manifolds])
         point_layout = tuple(manifold.point_layout for manifold in manifolds)
-        # TODO: set a backend to be able to accss
         super().__init__(
             name,
             dimension,
             point_layout=point_layout,
-            backend=manifolds[0].backend,
-        )
-
-    @Manifold.backend.setter
-    def backend(self, backend: Backend):
-        warnings.warn(
-            "Setting backend of Product manifold is not supported. "
-            "One should directly set the backend of each underlying manifold."
+            backend=manifolds[0].backend.to_real_backend(),
         )
 
     def has_dummy_backend(self) -> bool:
@@ -94,13 +83,13 @@ class Product(Manifold):
             for manifold in self.manifolds
         )
 
-    def set_backend_with_default_dtype(self, backend_type: type):
+    def set_compatible_backend(self, other_backend: Backend):
         for manifold in self.manifolds:
-            manifold.set_backend_with_default_dtype(backend_type)
+            manifold.set_compatible_backend(other_backend)
 
-    def is_backend_compatible(self, backend_type: type) -> bool:
+    def is_backend_compatible(self, other_backend: Backend) -> bool:
         return all(
-            manifold.is_backend_compatible(backend_type)
+            manifold.is_backend_compatible(other_backend)
             for manifold in self.manifolds
         )
 

--- a/src/pymanopt/manifolds/product.py
+++ b/src/pymanopt/manifolds/product.py
@@ -74,6 +74,9 @@ class Product(Manifold):
             name,
             dimension,
             point_layout=point_layout,
+            # here we arbitrarily use the real version of the backend since
+            # it won't be used for any computation, only possibly for settting
+            # the backend of a function
             backend=manifolds[0].backend.to_real_backend(),
         )
 

--- a/src/pymanopt/manifolds/product.py
+++ b/src/pymanopt/manifolds/product.py
@@ -84,6 +84,7 @@ class Product(Manifold):
         )
 
     def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
         for manifold in self.manifolds:
             manifold.set_compatible_backend(other_backend)
 

--- a/src/pymanopt/manifolds/sphere.py
+++ b/src/pymanopt/manifolds/sphere.py
@@ -202,12 +202,12 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
         dimension = subspace_dimension - 1
         super().__init__(name, dimension, matrix, subspace_projector, backend)
 
-    @RiemannianSubmanifold.backend.setter
-    def _(self, backend: Backend):
-        super().backend = backend
-        self._matrix = backend.array(self._matrix)
-        q, _ = backend.linalg_qr(self._matrix)
-        self._subspace_projector = q @ self.backend.transpose(q)
+    def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
+        bk = self.backend
+        self._matrix = bk.array(self._matrix)
+        q, _ = bk.linalg_qr(self._matrix)
+        self._subspace_projector = q @ bk.transpose(q)
 
 
 @extend_docstring(DOCSTRING_NOTE)

--- a/src/pymanopt/manifolds/sphere.py
+++ b/src/pymanopt/manifolds/sphere.py
@@ -182,32 +182,39 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
         matrix: Matrix whose columns span the intersecting subspace.
     """
 
+    @staticmethod
+    def _compute_subspace_projector(bk: Backend, matrix: Backend.array_t):
+        matrix = bk.array(matrix)
+        q, _ = bk.linalg_qr(matrix)
+        _subspace_projector = bk.eye(matrix.shape[0]) - q @ q.T
+        return matrix, _subspace_projector
+
     def __init__(
         self,
         matrix,
         backend: Backend = NumpyBackend(),  # noqa: B008
     ):
-        if backend is None:
+        if backend == DummyBackendSingleton:
             raise ValueError(
                 f"A backend must always be specified for class {__class__.__name__}"
             )
-        m = matrix.shape[0]
-        q, _ = backend.linalg_qr(matrix)
-        subspace_projector = q @ backend.transpose(q)
+        matrix, subspace_projector = self._compute_subspace_projector(
+            backend, matrix
+        )
         subspace_dimension = backend.linalg_matrix_rank(subspace_projector)
         name = (
-            f"Sphere manifold of {m}-dimensional vectors intersecting a "
-            f"{subspace_dimension}-dimensional subspace"
+            f"Sphere manifold of {matrix.shape[0]}-dimensional vectors "
+            f"intersecting a {subspace_dimension}-dimensional subspace"
         )
         dimension = subspace_dimension - 1
         super().__init__(name, dimension, matrix, subspace_projector, backend)
 
     def set_compatible_backend(self, other_backend: Backend):
         super().set_compatible_backend(other_backend)
-        bk = self.backend
-        self._matrix = bk.array(self._matrix)
-        q, _ = bk.linalg_qr(self._matrix)
-        self._subspace_projector = q @ bk.transpose(q)
+        (
+            self._matrix,
+            self._subspace_projector,
+        ) = self._compute_subspace_projector(self.backend, self._matrix)
 
 
 @extend_docstring(DOCSTRING_NOTE)
@@ -225,31 +232,36 @@ class SphereSubspaceComplementIntersection(
         matrix: Matrix whose columns span the subspace.
     """
 
+    @staticmethod
+    def _compute_subspace_projector(bk: Backend, matrix: Backend.array_t):
+        matrix = bk.array(matrix)
+        q, _ = bk.linalg_qr(matrix)
+        _subspace_projector = bk.eye(matrix.shape[0]) - q @ q.T
+        return matrix, _subspace_projector
+
     def __init__(
         self,
         matrix,
         backend: Backend = NumpyBackend(),  # noqa: B008
     ):
-        if backend is None:
+        if backend == DummyBackendSingleton:
             raise ValueError(
                 f"A backend must always be specified for class {__class__.__name__}"
             )
-        m = matrix.shape[0]
-        q, _ = backend.linalg_qr(matrix)
-        subspace_projector = backend.eye(m) - q @ backend.transpose(q)
+        matrix, subspace_projector = self._compute_subspace_projector(
+            backend, matrix
+        )
         subspace_dimension = backend.linalg_matrix_rank(subspace_projector)
         name = (
-            f"Sphere manifold of {m}-dimensional vectors orthogonal "
+            f"Sphere manifold of {matrix.shape[0]}-dimensional vectors orthogonal "
             f"to a {subspace_dimension}-dimensional subspace"
         )
         dimension = subspace_dimension - 1
         super().__init__(name, dimension, matrix, subspace_projector, backend)
 
-    @RiemannianSubmanifold.backend.setter
-    def _(self, backend: Backend):
-        super().backend = backend
-        self._matrix = backend.array(self._matrix)
-        q, _ = backend.linalg_qr(self._matrix)
-        self._subspace_projector = backend.eye(
-            self.dim
-        ) - q @ self.backend.transpose(q)
+    def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
+        (
+            self._matrix,
+            self._subspace_projector,
+        ) = self._compute_subspace_projector(self.backend, self._matrix)

--- a/src/pymanopt/manifolds/sphere.py
+++ b/src/pymanopt/manifolds/sphere.py
@@ -186,7 +186,7 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
     def _compute_subspace_projector(bk: Backend, matrix: Backend.array_t):
         matrix = bk.array(matrix)
         q, _ = bk.linalg_qr(matrix)
-        _subspace_projector = bk.eye(matrix.shape[0]) - q @ q.T
+        _subspace_projector = q @ q.T
         return matrix, _subspace_projector
 
     def __init__(

--- a/src/pymanopt/optimizers/nelder_mead.py
+++ b/src/pymanopt/optimizers/nelder_mead.py
@@ -12,14 +12,12 @@ from pymanopt.optimizers.steepest_descent import SteepestDescent
 def compute_centroid(manifold, points):
     """Compute the centroid of `points` on the `manifold` as Karcher mean."""
 
-    @pymanopt.function.numpy(manifold)
     def objective(*y):
         if manifold.num_values == 1:
             (y,) = y
         return sum(manifold.dist(y, point) ** 2 for point in points) / 2
 
-    @pymanopt.function.numpy(manifold)
-    def gradient(*y):
+    def riemannian_gradient(*y):
         if manifold.num_values == 1:
             (y,) = y
         return -sum(
@@ -29,7 +27,7 @@ def compute_centroid(manifold, points):
 
     optimizer = SteepestDescent(max_iterations=15, verbosity=0)
     problem = pymanopt.Problem(
-        manifold, objective, riemannian_gradient=gradient
+        manifold, objective, riemannian_gradient=riemannian_gradient
     )
     return optimizer.run(problem).point
 

--- a/src/pymanopt/optimizers/nelder_mead.py
+++ b/src/pymanopt/optimizers/nelder_mead.py
@@ -10,7 +10,7 @@ from pymanopt.optimizers.steepest_descent import SteepestDescent
 
 
 def compute_centroid(manifold, points):
-    """Compute the centroid of `points` on the `manifold` as Karcher mean."""
+    """Compute the centroid of `points` on the `manifold` as intrinsic mean."""
 
     def objective(*y):
         if manifold.num_values == 1:

--- a/tests/manifolds/test_fixed_rank.py
+++ b/tests/manifolds/test_fixed_rank.py
@@ -160,7 +160,9 @@ class TestFixedRankEmbeddedManifold:
             bk.transpose(z) @ w, m._apply_ambient_transpose(z, w)
         )
         bk.assert_allclose(
-            bk.transpose(z) @ w, m._apply_ambient_transpose((u, s, v), w)
+            bk.transpose(z) @ w,
+            m._apply_ambient_transpose((u, s, v), w),
+            atol=5e-5,
         )
 
     def test_embedding(self):


### PR DESCRIPTION
In this PR:
- we add notion of dtype precision (32 or 64 bits) with the enum `DTypePrecision`
- we define *compatible backends* as backends with the same type (i.e. the implementation) and dtype precision (but that may differ in realness)
- we enforce compatibility of backends between functions (cost and manually specified derivatives) and manifolds in a problem
- we enforce compatibility of backends of manifolds in a product, and now add a backend for the product itself. It is directly determined from the backends of the underlying manifolds and was (arbitrarily) chosen convention to be the real version compatible with the others (which should not impact anything).
- we replace the old `Manifold.backend.setter` by a method `Manifold.set_compatible_backend(other_backend)` that is a safe setter enforcing backend compatibility
- we allow now specifying functions (cost and its derivatives) as pure python functions and then convert them to `Function` inside the `Problem` based on the backend of the `Manifold`. We raise an exception if neither the functions nor the manifold have a backend.

> [!NOTE]
> This PR (#284) is stacked with #285 and #286 (and is at the bottom of the stack). This means that the branch of #285 is based on the one of #284 and the branch of #286 on the branch of #285. They each treat different issues in the codebase and were split to facilitate reviewing. However, there are still unit tests failing in the first ones, and they are only totally fixed in the last. Thanks for taking that into account during the review.