### PR TITLE
Fix autodiff issues with `pytorch` backend

### DIFF
--- a/examples/advanced/check_gradient.py
+++ b/examples/advanced/check_gradient.py
@@ -39,14 +39,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ x
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(x):
             return -x @ matrix @ x
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(x):

--- a/examples/advanced/check_hessian.py
+++ b/examples/advanced/check_hessian.py
@@ -44,14 +44,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ d
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(x):
             return -x @ matrix @ x
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(x):

--- a/examples/closest_unit_norm_column_approximation.py
+++ b/examples/closest_unit_norm_column_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Oblique
 from pymanopt.optimizers import ConjugateGradient
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -38,14 +40,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return X - matrix
 
     elif backend == "pytorch":
-        matrix_ = torch.from_numpy(matrix).to(torch.float32)
+        matrix_ = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return 0.5 * torch.sum((X - matrix_) ** 2)
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/dominant_eigenvector.py
+++ b/examples/dominant_eigenvector.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Sphere
 from pymanopt.optimizers import SteepestDescent
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -38,14 +40,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ x
 
     elif backend == "pytorch":
-        matrix_ = torch.from_numpy(matrix).to(dtype=torch.float32)
+        matrix_ = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(x):
             return -x.reshape(1, -1) @ matrix_ @ x.reshape(-1, 1)
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(x):

--- a/examples/dominant_invariant_complex_subspace.py
+++ b/examples/dominant_invariant_complex_subspace.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import ComplexGrassmann
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,14 +44,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ H
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.complex64)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return -torch.tensordot(X.conj(), matrix @ X).real
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.complex64)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/dominant_invariant_subspace.py
+++ b/examples/dominant_invariant_subspace.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Grassmann
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,14 +44,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ H
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return -torch.tensordot(X, matrix @ X)
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/low_rank_matrix_approximation.py
+++ b/examples/low_rank_matrix_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import FixedRankEmbedded
 from pymanopt.optimizers import ConjugateGradient
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -46,7 +48,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return gu, gs, gvt
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(u, s, vt):
@@ -54,7 +56,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return torch.norm(X - matrix) ** 2
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(u, s, vt):

--- a/examples/low_rank_psd_matrix_approximation.py
+++ b/examples/low_rank_psd_matrix_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import PSDFixedRank
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,7 +44,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return 4 * ((Y @ U.T + U @ Y.T) @ Y + (Y @ Y.T - matrix) @ U)
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(Y):
@@ -50,7 +52,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return torch.norm(X - matrix) ** 2
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(Y):

--- a/examples/multiple_linear_regression.py
+++ b/examples/multiple_linear_regression.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Euclidean
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,16 +44,16 @@ def create_cost_and_derivates(manifold, samples, targets, backend):
             return 2 * samples.T @ samples @ vector
 
     elif backend == "pytorch":
-        samples = torch.from_numpy(samples).to(torch.float32)
-        targets = torch.from_numpy(targets).to(torch.float32)
+        samples = torch.from_numpy(samples)
+        targets = torch.from_numpy(targets)
 
         @pymanopt.function.pytorch(manifold)
         def cost(weights):
             return torch.norm(targets - samples @ weights) ** 2
 
     elif backend == "tensorflow":
-        samples = tf.constant(samples, dtype=tf.float32)
-        targets = tf.constant(targets, dtype=tf.float32)
+        samples = tf.constant(samples)
+        targets = tf.constant(targets)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(weights):

--- a/examples/optimal_rotations.py
+++ b/examples/optimal_rotations.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import SpecialOrthogonalGroup
 from pymanopt.optimizers import SteepestDescent
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -38,14 +40,14 @@ def create_cost_and_derivates(manifold, ABt, backend):
             return -ABt
 
     elif backend == "pytorch":
-        ABt = torch.from_numpy(ABt).to(torch.float32)
+        ABt = torch.from_numpy(ABt)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return -torch.tensordot(X, ABt, dims=X.dim())
 
     elif backend == "tensorflow":
-        ABt = tf.constant(ABt, dtype=tf.float32)
+        ABt = tf.constant(ABt)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/pca.py
+++ b/examples/pca.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Stiefel
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -56,7 +58,7 @@ def create_cost_and_derivates(manifold, samples, backend):
             )
 
     elif backend == "pytorch":
-        samples = torch.from_numpy(samples).to(torch.float32)
+        samples = torch.from_numpy(samples)
 
         @pymanopt.function.pytorch(manifold)
         def cost(w):
@@ -64,7 +66,7 @@ def create_cost_and_derivates(manifold, samples, backend):
             return torch.norm(samples - samples @ projector) ** 2
 
     elif backend == "tensorflow":
-        samples = tf.constant(samples, dtype=tf.float32)
+        samples = tf.constant(samples)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(w):
@@ -82,7 +84,11 @@ def run(backend=SUPPORTED_BACKENDS[0], quiet=True):
     num_samples = 200
     num_components = 2
     samples = np.random.normal(size=(num_samples, dimension)) @ np.diag(
-        [3, 2, 1]
+        [
+            3,
+            2,
+            1,
+        ]
     )
     samples -= samples.mean(axis=0)
 

--- a/examples/rank_k_correlation_matrix_approximation.py
+++ b/examples/rank_k_correlation_matrix_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Oblique
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,7 +44,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return X @ (H.T @ X + X.T @ H) + H @ (X.T @ X - matrix)
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
@@ -51,7 +53,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             )
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from numbers import Number
 from typing import Any, Callable, Literal, Optional, Union
 
@@ -11,6 +12,14 @@ from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
 )
+
+
+def conjugate_result(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        return list(map(torch.conj, function(*args, **kwargs)))  # type: ignore
+
+    return wrapper
 
 
 def elementary_math_function(
@@ -108,53 +117,36 @@ class PytorchBackend(Backend):
     ##############################################################################
     # Autodiff methods
     ##############################################################################
+    # TODO: remove this function
     def prepare_function(self, function):
         return function
 
-    def _sanitize_argument(self, arg: torch.Tensor):
-        arg.requires_grad_()
-        arg.grad = None
-        return arg
-
-    def _sanitize_gradient(self, tensor):
-        if tensor.grad is None:
-            return torch.zeros_like(tensor)
-        return tensor.grad
-
-    def generate_gradient_operator(self, function, num_arguments):
-        def gradient(*args):
-            arguments = list(map(self._sanitize_argument, args))
-            function(*arguments).backward(retain_graph=True)
-            return list(map(self._sanitize_gradient, arguments))
+    def generate_gradient_operator(self, function, num_arguments) -> Callable:
+        @conjugate_result
+        def gradient(*args: torch.Tensor):
+            for arg in args:
+                arg.requires_grad_(True)
+            f = function(*args)
+            grads = autograd.grad(f, args)  # type: ignore
+            for arg in args:
+                arg.requires_grad_(False)
+            return grads
 
         if num_arguments == 1:
             return unpack_singleton_sequence_return_value(gradient)
+
         return gradient
 
     def generate_hessian_operator(self, function, num_arguments):
-        def hessian_vector_product(*args):
-            arguments, vectors = bisect_sequence(args)
-            arguments = list(map(self._sanitize_argument, arguments))
-            gradients = autograd.grad(
-                function(*arguments),
-                arguments,
-                create_graph=True,
-                allow_unused=True,
-                retain_graph=True,
-            )
-            dot_product: torch.Tensor = torch.tensor(0.0)
-            for gradient, vector in zip(gradients, vectors):
-                dot_product += torch.tensordot(
-                    gradient.conj(), vector, dims=gradient.ndim
-                ).real
-            dot_product.backward(retain_graph=True)
-            return list(map(self._sanitize_gradient, arguments))
+        @conjugate_result
+        def hvp(*inputs: torch.Tensor):
+            args, vectors = bisect_sequence(inputs)
+            return autograd.functional.hvp(function, args, vectors)[1]
 
         if num_arguments == 1:
-            return unpack_singleton_sequence_return_value(
-                hessian_vector_product
-            )
-        return hessian_vector_product
+            return unpack_singleton_sequence_return_value(hvp)
+
+        return hvp
 
     ##############################################################################
     # Numerics functions

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from numbers import Number
 from typing import Any, Callable, Literal, Optional, Union
 
@@ -12,14 +11,6 @@ from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
 )
-
-
-def conjugate_result(function):
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        return list(map(torch.conj, function(*args, **kwargs)))  # type: ignore
-
-    return wrapper
 
 
 def elementary_math_function(
@@ -122,12 +113,10 @@ class PytorchBackend(Backend):
         return function
 
     def generate_gradient_operator(self, function, num_arguments) -> Callable:
-        @conjugate_result
         def gradient(*args: torch.Tensor):
             for arg in args:
                 arg.requires_grad_(True)
-            f = function(*args)
-            grads = autograd.grad(f, args)  # type: ignore
+            grads = autograd.grad(function(*args), args)  # type: ignore
             for arg in args:
                 arg.requires_grad_(False)
             return grads
@@ -138,7 +127,6 @@ class PytorchBackend(Backend):
         return gradient
 
     def generate_hessian_operator(self, function, num_arguments):
-        @conjugate_result
         def hvp(*inputs: torch.Tensor):
             args, vectors = bisect_sequence(inputs)
             return autograd.functional.hvp(function, args, vectors)[1]

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -71,7 +71,7 @@ class Manifold(metaclass=abc.ABCMeta):
                 f"{type(point_layout)}"
             )
         if isinstance(point_layout, (tuple, list)):
-            if not all([num_arguments > 0 for num_arguments in point_layout]):
+            if not all(num_arguments > 0 for num_arguments in point_layout):
                 raise ValueError(
                     f"Invalid point layout {point_layout}: all values must be "
                     "positive"

--- a/tests/manifolds/test_group.py
+++ b/tests/manifolds/test_group.py
@@ -70,7 +70,7 @@ class TestSpecialOrthogonalGroup:
         X = s.random_point()
         Y = s.random_point()
         Yexplog = s.exp(X, s.log(X, Y))
-        self.backend.assert_allclose(Y, Yexplog)
+        self.backend.assert_allclose(Y, Yexplog, atol=5e-6)
 
     def test_log_exp_inverse(self):
         s = self.so

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,8 @@ from examples import (
 from examples.advanced import check_gradient, check_hessian, check_retraction
 
 
-SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch", "tensorflow"}
+# TODO: add back tensorflow
+SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch"}
 
 
 class TestExamples:


### PR DESCRIPTION
Before, the inputs on which the cost and its derivatives were applied were `np.array`s translated on-the-fly to `torch.tensor`s that had by default the correct metadata (like `requires_grad`). Since now we reuse already existing tensors, we have to correctly handle this metadata ourselves.

This PR achieves that while also greatly simplifying the code and leveraging more functions from the [`torch.autograd`](https://pytorch.org/docs/stable/autograd.html) module (like we do for the other backend implementations).

Finally, this PR also uses `float64` precisions for all `test_examples` (to ensure the defined tolerances are consistent throughout the backends).

> [!NOTE]
> This PR (#285) is stacked with #284 and #286. This means that the branch of #285 is based on the one of #284 and the branch of #286 on the branch of #285. They each treat different issues in the codebase and were split to facilitate reviewing. However, there are still unit tests failing in the first ones, and they are only totally fixed in the last. Thanks for taking that into account during the review.