### PR TITLE
Rework `diagnostics.py`

### DIFF
--- a/examples/advanced/check_gradient.py
+++ b/examples/advanced/check_gradient.py
@@ -39,14 +39,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ x
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(x):
             return -x @ matrix @ x
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(x):

--- a/examples/advanced/check_hessian.py
+++ b/examples/advanced/check_hessian.py
@@ -44,14 +44,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ d
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(x):
             return -x @ matrix @ x
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(x):

--- a/examples/closest_unit_norm_column_approximation.py
+++ b/examples/closest_unit_norm_column_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Oblique
 from pymanopt.optimizers import ConjugateGradient
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -38,14 +40,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return X - matrix
 
     elif backend == "pytorch":
-        matrix_ = torch.from_numpy(matrix).to(torch.float32)
+        matrix_ = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return 0.5 * torch.sum((X - matrix_) ** 2)
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/dominant_eigenvector.py
+++ b/examples/dominant_eigenvector.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Sphere
 from pymanopt.optimizers import SteepestDescent
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -38,14 +40,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ x
 
     elif backend == "pytorch":
-        matrix_ = torch.from_numpy(matrix).to(dtype=torch.float32)
+        matrix_ = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(x):
             return -x.reshape(1, -1) @ matrix_ @ x.reshape(-1, 1)
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(x):

--- a/examples/dominant_invariant_complex_subspace.py
+++ b/examples/dominant_invariant_complex_subspace.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import ComplexGrassmann
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,14 +44,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ H
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.complex64)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return -torch.tensordot(X.conj(), matrix @ X).real
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.complex64)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/dominant_invariant_subspace.py
+++ b/examples/dominant_invariant_subspace.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Grassmann
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,14 +44,14 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return -2 * matrix @ H
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return -torch.tensordot(X, matrix @ X)
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/low_rank_matrix_approximation.py
+++ b/examples/low_rank_matrix_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import FixedRankEmbedded
 from pymanopt.optimizers import ConjugateGradient
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -46,7 +48,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return gu, gs, gvt
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(u, s, vt):
@@ -54,7 +56,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return torch.norm(X - matrix) ** 2
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(u, s, vt):

--- a/examples/low_rank_psd_matrix_approximation.py
+++ b/examples/low_rank_psd_matrix_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import PSDFixedRank
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,7 +44,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return 4 * ((Y @ U.T + U @ Y.T) @ Y + (Y @ Y.T - matrix) @ U)
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(Y):
@@ -50,7 +52,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return torch.norm(X - matrix) ** 2
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(Y):

--- a/examples/multiple_linear_regression.py
+++ b/examples/multiple_linear_regression.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Euclidean
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,16 +44,16 @@ def create_cost_and_derivates(manifold, samples, targets, backend):
             return 2 * samples.T @ samples @ vector
 
     elif backend == "pytorch":
-        samples = torch.from_numpy(samples).to(torch.float32)
-        targets = torch.from_numpy(targets).to(torch.float32)
+        samples = torch.from_numpy(samples)
+        targets = torch.from_numpy(targets)
 
         @pymanopt.function.pytorch(manifold)
         def cost(weights):
             return torch.norm(targets - samples @ weights) ** 2
 
     elif backend == "tensorflow":
-        samples = tf.constant(samples, dtype=tf.float32)
-        targets = tf.constant(targets, dtype=tf.float32)
+        samples = tf.constant(samples)
+        targets = tf.constant(targets)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(weights):

--- a/examples/optimal_rotations.py
+++ b/examples/optimal_rotations.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import SpecialOrthogonalGroup
 from pymanopt.optimizers import SteepestDescent
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -38,14 +40,14 @@ def create_cost_and_derivates(manifold, ABt, backend):
             return -ABt
 
     elif backend == "pytorch":
-        ABt = torch.from_numpy(ABt).to(torch.float32)
+        ABt = torch.from_numpy(ABt)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
             return -torch.tensordot(X, ABt, dims=X.dim())
 
     elif backend == "tensorflow":
-        ABt = tf.constant(ABt, dtype=tf.float32)
+        ABt = tf.constant(ABt)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/examples/pca.py
+++ b/examples/pca.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Stiefel
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -56,7 +58,7 @@ def create_cost_and_derivates(manifold, samples, backend):
             )
 
     elif backend == "pytorch":
-        samples = torch.from_numpy(samples).to(torch.float32)
+        samples = torch.from_numpy(samples)
 
         @pymanopt.function.pytorch(manifold)
         def cost(w):
@@ -64,7 +66,7 @@ def create_cost_and_derivates(manifold, samples, backend):
             return torch.norm(samples - samples @ projector) ** 2
 
     elif backend == "tensorflow":
-        samples = tf.constant(samples, dtype=tf.float32)
+        samples = tf.constant(samples)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(w):
@@ -82,7 +84,11 @@ def run(backend=SUPPORTED_BACKENDS[0], quiet=True):
     num_samples = 200
     num_components = 2
     samples = np.random.normal(size=(num_samples, dimension)) @ np.diag(
-        [3, 2, 1]
+        [
+            3,
+            2,
+            1,
+        ]
     )
     samples -= samples.mean(axis=0)
 

--- a/examples/rank_k_correlation_matrix_approximation.py
+++ b/examples/rank_k_correlation_matrix_approximation.py
@@ -9,6 +9,8 @@ from pymanopt.manifolds import Oblique
 from pymanopt.optimizers import TrustRegions
 
 
+np.random.seed(127)
+
 SUPPORTED_BACKENDS = ("autograd", "jax", "numpy", "pytorch", "tensorflow")
 
 
@@ -42,7 +44,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             return X @ (H.T @ X + X.T @ H) + H @ (X.T @ X - matrix)
 
     elif backend == "pytorch":
-        matrix = torch.from_numpy(matrix).to(torch.float32)
+        matrix = torch.from_numpy(matrix)
 
         @pymanopt.function.pytorch(manifold)
         def cost(X):
@@ -51,7 +53,7 @@ def create_cost_and_derivates(manifold, matrix, backend):
             )
 
     elif backend == "tensorflow":
-        matrix = tf.constant(matrix, dtype=tf.float32)
+        matrix = tf.constant(matrix)
 
         @pymanopt.function.tensorflow(manifold)
         def cost(X):

--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -509,16 +509,6 @@ class Backend(ABC):
     pi = np.pi
 
     @not_implemented
-    def polyfit(
-        self, x: array_t, y: array_t, deg: int = 1, full: bool = False
-    ) -> Union[array_t, tuple[array_t, array_t]]:
-        ...
-
-    @not_implemented
-    def polyval(self, p: array_t, x: array_t) -> array_t:
-        ...
-
-    @not_implemented
     def prod(self, array: array_t) -> float:
         ...
 

--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -45,7 +45,6 @@ class Backend(ABC):
     # Common attributes, properties and methods
     ##########################################################################
     _dtype: type
-    _dtype_precision: DTypePrecision
 
     @runtime_checkable  # to be able to check isinstance(x, bk.array_t)
     class array_t(Protocol):
@@ -144,6 +143,7 @@ class Backend(ABC):
         ...
 
     @property
+    @abstractmethod
     def dtype_precision(self) -> DTypePrecision:
         ...
 

--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from enum import Enum
 from functools import wraps
 from typing import (
     Callable,
@@ -14,7 +15,7 @@ import numpy as np
 import scipy.special
 
 
-__all__ = ["TupleOrList", "Backend", "DummyBackendSingleton"]
+__all__ = ["TupleOrList", "DTypePrecision", "Backend", "DummyBackendSingleton"]
 
 T = TypeVar("T")
 TupleOrList = Union[list[T], tuple[T, ...]]
@@ -30,6 +31,13 @@ def not_implemented(function):
     return inner
 
 
+class DTypePrecision(Enum):
+    """Enum for the dtype precision of the backend."""
+
+    SINGLE = 32
+    DOUBLE = 64
+
+
 class Backend(ABC):
     """Abstract base class defining the interface for autodiff backends."""
 
@@ -37,8 +45,9 @@ class Backend(ABC):
     # Common attributes, properties and methods
     ##########################################################################
     _dtype: type
+    _dtype_precision: DTypePrecision
 
-    @runtime_checkable
+    @runtime_checkable  # to be able to check isinstance(x, bk.array_t)
     class array_t(Protocol):
         """Array type used for static type checks.
 
@@ -132,6 +141,10 @@ class Backend(ABC):
     @property
     @abstractmethod
     def dtype(self) -> type:
+        ...
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
         ...
 
     @property

--- a/src/pymanopt/backends/backend.py
+++ b/src/pymanopt/backends/backend.py
@@ -699,6 +699,10 @@ class DummyBackend(Backend):
         ...
 
     @property
+    def dtype_precision(self):
+        ...
+
+    @property
     def is_dtype_real(self):
         ...
 

--- a/src/pymanopt/backends/jax_backend.py
+++ b/src/pymanopt/backends/jax_backend.py
@@ -49,11 +49,6 @@ class JaxBackend(Backend):
         ), f"dtype {dtype} is not supported"
         self._dtype = dtype
         self._random_key = jax.random.key(random_seed)
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if (dtype == jnp.float32 or dtype == jnp.complex64)
-            else DTypePrecision.DOUBLE
-        )
 
     def _gen_1_random_key(self):
         self._random_key, new_key = jax.random.split(self._random_key)
@@ -68,6 +63,14 @@ class JaxBackend(Backend):
     @property
     def dtype(self) -> jnp.dtype:
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == jnp.float32 or self.dtype == jnp.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/jax_backend.py
+++ b/src/pymanopt/backends/jax_backend.py
@@ -8,7 +8,7 @@ import jax.scipy as jscipy
 import numpy as np
 import scipy.linalg
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
@@ -41,8 +41,19 @@ class JaxBackend(Backend):
     _dtype: jnp.dtype
 
     def __init__(self, dtype=jnp.float64, random_seed: int = 42):
+        assert (
+            dtype == jnp.float32
+            or dtype == jnp.float64
+            or dtype == jnp.complex64
+            or dtype == jnp.complex128
+        ), f"dtype {dtype} is not supported"
         self._dtype = dtype
         self._random_key = jax.random.key(random_seed)
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if (dtype == jnp.float32 or dtype == jnp.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     def _gen_1_random_key(self):
         self._random_key, new_key = jax.random.split(self._random_key)
@@ -64,11 +75,11 @@ class JaxBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return jnp.array([1.0]).dtype
+        return jnp.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return jnp.array([1j]).dtype
+        return jnp.complex128
 
     def __repr__(self):
         return f"JaxBackend(dtype={self.dtype})"

--- a/src/pymanopt/backends/jax_backend.py
+++ b/src/pymanopt/backends/jax_backend.py
@@ -382,14 +382,6 @@ class JaxBackend(Backend):
     def ones_bool(self, shape: TupleOrList[int]) -> jnp.ndarray:
         return jnp.ones(shape, bool)
 
-    def polyfit(
-        self, x: jnp.ndarray, y: jnp.ndarray, deg: int = 1, full: bool = False
-    ) -> Union[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]]:
-        return jnp.polyfit(x, y, deg, full=full)  # type: ignore
-
-    def polyval(self, p: jnp.ndarray, x: jnp.ndarray) -> jnp.ndarray:
-        return jnp.polyval(p, x)
-
     def prod(self, array: jnp.ndarray) -> float:
         return jnp.prod(array)  # type: ignore
 

--- a/src/pymanopt/backends/numpy_backend.py
+++ b/src/pymanopt/backends/numpy_backend.py
@@ -7,7 +7,7 @@ import packaging.version as pv
 import scipy
 import scipy.linalg
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 
 
 def _raise_not_implemented_error(*args, **kwargs):
@@ -35,6 +35,11 @@ class NumpyBackend(Backend):
             or dtype == np.complex128
         ), f"dtype {dtype} is not supported"
         self._dtype = dtype
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if (dtype == np.float32 or dtype == np.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def dtype(self):
@@ -46,11 +51,11 @@ class NumpyBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return np.array([1.0]).dtype
+        return np.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return np.array([1j]).dtype
+        return np.complex128
 
     def __repr__(self):
         return f"NumpyBackend(dtype={self.dtype})"

--- a/src/pymanopt/backends/numpy_backend.py
+++ b/src/pymanopt/backends/numpy_backend.py
@@ -331,14 +331,6 @@ class NumpyBackend(Backend):
     def ones_bool(self, shape: TupleOrList[int]) -> np.ndarray:
         return np.ones(shape, bool)
 
-    def polyfit(
-        self, x: np.ndarray, y: np.ndarray, deg: int = 1, full: bool = False
-    ) -> Union[np.ndarray, tuple[np.ndarray, np.ndarray]]:
-        return np.polyfit(x, y, deg, full=full)  # type: ignore
-
-    def polyval(self, p: np.ndarray, x: np.ndarray) -> np.ndarray:
-        return np.polyval(p, x)
-
     def prod(self, array: np.ndarray) -> float:
         return np.prod(array)  # type: ignore
 

--- a/src/pymanopt/backends/numpy_backend.py
+++ b/src/pymanopt/backends/numpy_backend.py
@@ -35,15 +35,18 @@ class NumpyBackend(Backend):
             or dtype == np.complex128
         ), f"dtype {dtype} is not supported"
         self._dtype = dtype
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if (dtype == np.float32 or dtype == np.complex64)
-            else DTypePrecision.DOUBLE
-        )
 
     @property
     def dtype(self):
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == np.float32 or self.dtype == np.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -6,7 +6,7 @@ import scipy.linalg
 import torch
 from torch import autograd
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
@@ -47,6 +47,11 @@ class PytorchBackend(Backend):
             torch.complex128,
         }
         self._dtype = dtype
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if dtype in {torch.float32, torch.complex64}
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def dtype(self):
@@ -58,11 +63,11 @@ class PytorchBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return torch.tensor([1.0]).dtype
+        return torch.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return torch.tensor([1j]).dtype
+        return torch.complex128
 
     def to_real_backend(self) -> "PytorchBackend":
         if self.is_dtype_real:

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -460,25 +460,6 @@ class PytorchBackend(Backend):
     def ones_bool(self, shape: TupleOrList[int]) -> torch.Tensor:
         return torch.ones(shape, dtype=torch.bool)
 
-    def polyfit(
-        self,
-        x: torch.Tensor,
-        y: torch.Tensor,
-        deg: int = 1,
-        full: bool = False,
-    ) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
-        assert x.ndim == y.ndim == 1
-        x = torch.stack([x**i for i in range(deg + 1)], dim=-1)
-        p = torch.linalg.lstsq(x, y).solution
-        if not full:
-            return p
-        res = torch.sum((y - x @ p) ** 2)
-        return p, res
-
-    def polyval(self, p: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
-        assert x.ndim == p.ndim == 1
-        return torch.stack([x**i for i in range(p.shape[0])], dim=-1) @ p
-
     def prod(self, array: torch.Tensor) -> float:
         return torch.prod(array).item()
 

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from numbers import Number
 from typing import Any, Callable, Literal, Optional, Union
 
@@ -11,6 +12,14 @@ from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
 )
+
+
+def conjugate_result(function):
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        return list(map(torch.conj, function(*args, **kwargs)))  # type: ignore
+
+    return wrapper
 
 
 def elementary_math_function(
@@ -108,53 +117,36 @@ class PytorchBackend(Backend):
     ##############################################################################
     # Autodiff methods
     ##############################################################################
+    # TODO: remove this function
     def prepare_function(self, function):
         return function
 
-    def _sanitize_argument(self, arg: torch.Tensor):
-        arg.requires_grad_()
-        arg.grad = None
-        return arg
-
-    def _sanitize_gradient(self, tensor):
-        if tensor.grad is None:
-            return torch.zeros_like(tensor)
-        return tensor.grad
-
-    def generate_gradient_operator(self, function, num_arguments):
-        def gradient(*args):
-            arguments = list(map(self._sanitize_argument, args))
-            function(*arguments).backward(retain_graph=True)
-            return list(map(self._sanitize_gradient, arguments))
+    def generate_gradient_operator(self, function, num_arguments) -> Callable:
+        @conjugate_result
+        def gradient(*args: torch.Tensor):
+            for arg in args:
+                arg.requires_grad_(True)
+            f = function(*args)
+            grads = autograd.grad(f, args)  # type: ignore
+            for arg in args:
+                arg.requires_grad_(False)
+            return grads
 
         if num_arguments == 1:
             return unpack_singleton_sequence_return_value(gradient)
+
         return gradient
 
     def generate_hessian_operator(self, function, num_arguments):
-        def hessian_vector_product(*args):
-            arguments, vectors = bisect_sequence(args)
-            arguments = list(map(self._sanitize_argument, arguments))
-            gradients = autograd.grad(
-                function(*arguments),
-                arguments,
-                create_graph=True,
-                allow_unused=True,
-                retain_graph=True,
-            )
-            dot_product: torch.Tensor = torch.tensor(0.0)
-            for gradient, vector in zip(gradients, vectors):
-                dot_product += torch.tensordot(
-                    gradient.conj(), vector, dims=gradient.ndim
-                ).real
-            dot_product.backward(retain_graph=True)
-            return list(map(self._sanitize_gradient, arguments))
+        @conjugate_result
+        def hvp(*inputs: torch.Tensor):
+            args, vectors = bisect_sequence(inputs)
+            return autograd.functional.hvp(function, args, vectors)[1]
 
         if num_arguments == 1:
-            return unpack_singleton_sequence_return_value(
-                hessian_vector_product
-            )
-        return hessian_vector_product
+            return unpack_singleton_sequence_return_value(hvp)
+
+        return hvp
 
     ##############################################################################
     # Numerics functions

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -47,15 +47,18 @@ class PytorchBackend(Backend):
             torch.complex128,
         }
         self._dtype = dtype
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if dtype in {torch.float32, torch.complex64}
-            else DTypePrecision.DOUBLE
-        )
 
     @property
     def dtype(self):
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == torch.float32 or self.dtype == torch.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/pytorch_backend.py
+++ b/src/pymanopt/backends/pytorch_backend.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from numbers import Number
 from typing import Any, Callable, Literal, Optional, Union
 
@@ -12,14 +11,6 @@ from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
 )
-
-
-def conjugate_result(function):
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        return list(map(torch.conj, function(*args, **kwargs)))  # type: ignore
-
-    return wrapper
 
 
 def elementary_math_function(
@@ -122,12 +113,10 @@ class PytorchBackend(Backend):
         return function
 
     def generate_gradient_operator(self, function, num_arguments) -> Callable:
-        @conjugate_result
         def gradient(*args: torch.Tensor):
             for arg in args:
                 arg.requires_grad_(True)
-            f = function(*args)
-            grads = autograd.grad(f, args)  # type: ignore
+            grads = autograd.grad(function(*args), args)  # type: ignore
             for arg in args:
                 arg.requires_grad_(False)
             return grads
@@ -138,7 +127,6 @@ class PytorchBackend(Backend):
         return gradient
 
     def generate_hessian_operator(self, function, num_arguments):
-        @conjugate_result
         def hvp(*inputs: torch.Tensor):
             args, vectors = bisect_sequence(inputs)
             return autograd.functional.hvp(function, args, vectors)[1]

--- a/src/pymanopt/backends/tensorflow_backend.py
+++ b/src/pymanopt/backends/tensorflow_backend.py
@@ -55,15 +55,18 @@ class TensorflowBackend(Backend):
             tf.complex128,
         }, f"dtype {dtype} is not supported"
         self._dtype = dtype
-        self._dtype_precision = (
-            DTypePrecision.SINGLE
-            if dtype in {tf.float32, tf.complex64}
-            else DTypePrecision.DOUBLE
-        )
 
     @property
     def dtype(self) -> tf.DType:
         return self._dtype
+
+    @property
+    def dtype_precision(self) -> DTypePrecision:
+        return (
+            DTypePrecision.SINGLE
+            if (self.dtype == tf.float32 or self.dtype == tf.complex64)
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def is_dtype_real(self):

--- a/src/pymanopt/backends/tensorflow_backend.py
+++ b/src/pymanopt/backends/tensorflow_backend.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy
 import tensorflow as tf
 
-from pymanopt.backends.backend import Backend, TupleOrList
+from pymanopt.backends.backend import Backend, DTypePrecision, TupleOrList
 from pymanopt.tools import (
     bisect_sequence,
     unpack_singleton_sequence_return_value,
@@ -48,7 +48,18 @@ class TensorflowBackend(Backend):
     _dtype: tf.DType
 
     def __init__(self, dtype=tf.float64):
+        assert dtype in {
+            tf.float32,
+            tf.float64,
+            tf.complex64,
+            tf.complex128,
+        }, f"dtype {dtype} is not supported"
         self._dtype = dtype
+        self._dtype_precision = (
+            DTypePrecision.SINGLE
+            if dtype in {tf.float32, tf.complex64}
+            else DTypePrecision.DOUBLE
+        )
 
     @property
     def dtype(self) -> tf.DType:
@@ -60,11 +71,11 @@ class TensorflowBackend(Backend):
 
     @staticmethod
     def DEFAULT_REAL_DTYPE():
-        return tf.constant([1.0]).dtype
+        return tf.float64
 
     @staticmethod
     def DEFAULT_COMPLEX_DTYPE():
-        return tf.constant([1j]).dtype
+        return tf.complex128
 
     def __repr__(self):
         return f"TensorflowBackend(dtype={self.dtype})"

--- a/src/pymanopt/backends/tensorflow_backend.py
+++ b/src/pymanopt/backends/tensorflow_backend.py
@@ -452,25 +452,6 @@ class TensorflowBackend(Backend):
     def ones_bool(self, shape: TupleOrList[int]) -> tf.Tensor:
         return tf.ones(shape, dtype=tf.bool)
 
-    def polyfit(
-        self,
-        x: tf.Tensor,
-        y: tf.Tensor,
-        deg: int = 1,
-        full: bool = False,
-    ) -> Union[tf.Tensor, tuple[tf.Tensor, tf.Tensor]]:
-        assert x.ndim == y.ndim == 1
-        x = tf.stack([x**i for i in range(deg + 1)], axis=-1)
-        p = tf.squeeze(tf.linalg.lstsq(x, tf.reshape(y, (-1, 1))))
-        if not full:
-            return p
-        res = tf.reduce_sum((y - x @ p) ** 2)
-        return p, res
-
-    def polyval(self, p: tf.Tensor, x: tf.Tensor) -> tf.Tensor:
-        assert x.ndim == p.ndim == 1
-        return tf.stack([x**i for i in range(p.shape[0])], axis=-1) @ p
-
     def prod(self, array: tf.Tensor) -> float:
         return tf.reduce_prod(array).numpy().item()
 

--- a/src/pymanopt/core/problem.py
+++ b/src/pymanopt/core/problem.py
@@ -43,30 +43,39 @@ class Problem:
     def __init__(
         self,
         manifold: Manifold,
-        cost: Function,
+        cost: Callable,
         *,
-        euclidean_gradient: Optional[Function] = None,
-        riemannian_gradient: Optional[Function] = None,
-        euclidean_hessian: Optional[Function] = None,
-        riemannian_hessian: Optional[Function] = None,
+        euclidean_gradient: Optional[Callable] = None,
+        riemannian_gradient: Optional[Callable] = None,
+        euclidean_hessian: Optional[Callable] = None,
+        riemannian_hessian: Optional[Callable] = None,
         preconditioner: Optional[Callable] = None,
     ):
         self.manifold = manifold
 
-        self._validate_function(cost, "cost")
         for function, name in (
+            (cost, "cost"),
             (euclidean_gradient, "euclidean_gradient"),
             (euclidean_hessian, "euclidean_hessian"),
             (riemannian_gradient, "riemannian_gradient"),
             (riemannian_hessian, "riemannian_hessian"),
         ):
             if function is not None:
-                self._validate_function(function, name)
+                assert isinstance(
+                    function, Callable
+                ), f"Function {name} must be callable"
 
+        # check backend compatibility between manifold and cost function
+        assert isinstance(cost, Callable)
         if manifold.has_dummy_backend():
-            manifold.set_compatible_backend(cost.backend)
+            if isinstance(cost, Function):
+                manifold.set_compatible_backend(cost.backend)
+            else:
+                raise ValueError(
+                    "Neither cost nor manifold have a specified backend."
+                )
         else:
-            self._validate_function_backend(cost, "cost", manifold)
+            cost = self._validate_function_backend(cost, "cost", manifold)
 
         self._original_cost = cost
         self._cost = self._wrap_function(cost)
@@ -83,7 +92,7 @@ class Problem:
             )
 
         if euclidean_gradient is not None:
-            self._validate_function_backend(
+            euclidean_gradient = self._validate_function_backend(
                 euclidean_gradient, "euclidean_gradient", manifold
             )
             euclidean_gradient = self._wrap_gradient_operator(
@@ -91,7 +100,7 @@ class Problem:
             )
         self._euclidean_gradient = euclidean_gradient
         if euclidean_hessian is not None:
-            self._validate_function_backend(
+            euclidean_hessian = self._validate_function_backend(
                 euclidean_hessian, "euclidean_hessian", manifold
             )
             euclidean_hessian = self._wrap_hessian_operator(
@@ -100,7 +109,7 @@ class Problem:
         self._euclidean_hessian = euclidean_hessian
 
         if riemannian_gradient is not None:
-            self._validate_function_backend(
+            riemannian_gradient = self._validate_function_backend(
                 riemannian_gradient, "riemannian_gradient", manifold
             )
             riemannian_gradient = self._wrap_gradient_operator(
@@ -108,7 +117,7 @@ class Problem:
             )
         self._riemannian_gradient = riemannian_gradient
         if riemannian_hessian is not None:
-            self._validate_function_backend(
+            riemannian_hessian = self._validate_function_backend(
                 riemannian_hessian, "rimeannian_hessian", manifold
             )
             riemannian_hessian = self._wrap_hessian_operator(
@@ -136,13 +145,19 @@ class Problem:
 
     @staticmethod
     def _validate_function_backend(
-        function: Function, name: str, manifold: Manifold
+        function: Callable, name: str, manifold: Manifold
     ):
-        assert manifold.is_backend_compatible(function.backend), (
-            f"Function '{name}' has a backend {function.backend} "
-            "which is not compatible with the manifold's backend"
-            f" {manifold.backend}."
-        )
+        if isinstance(function, Function):
+            assert manifold.is_backend_compatible(function.backend), (
+                f"Function '{name}' has a backend {function.backend} "
+                "which is not compatible with the manifold's backend"
+                f" {manifold.backend}."
+            )
+            return function
+        else:
+            return Function(
+                function=function, manifold=manifold, backend=manifold.backend
+            )
 
     def _flatten_arguments(self, arguments, signature):
         assert len(arguments) == len(signature)

--- a/src/pymanopt/core/problem.py
+++ b/src/pymanopt/core/problem.py
@@ -53,19 +53,23 @@ class Problem:
     ):
         self.manifold = manifold
 
+        self._validate_function(cost, "cost")
         for function, name in (
-            (cost, "cost"),
             (euclidean_gradient, "euclidean_gradient"),
             (euclidean_hessian, "euclidean_hessian"),
             (riemannian_gradient, "riemannian_gradient"),
             (riemannian_hessian, "riemannian_hessian"),
         ):
-            self._validate_function(function, name)
+            if function is not None:
+                self._validate_function(function, name)
 
         if manifold.has_dummy_backend():
-            manifold.set_backend_with_default_dtype(type(cost.backend))
+            manifold.set_compatible_backend(cost.backend)
         else:
-            assert manifold.is_backend_compatible(type(cost.backend))
+            self._validate_function_backend(cost, "cost", manifold)
+
+        self._original_cost = cost
+        self._cost = self._wrap_function(cost)
 
         if euclidean_gradient is not None and riemannian_gradient is not None:
             raise ValueError(
@@ -78,26 +82,35 @@ class Problem:
                 "provided, not both"
             )
 
-        self._original_cost = cost
-        self._cost = self._wrap_function(cost)
-
         if euclidean_gradient is not None:
+            self._validate_function_backend(
+                euclidean_gradient, "euclidean_gradient", manifold
+            )
             euclidean_gradient = self._wrap_gradient_operator(
                 euclidean_gradient
             )
         self._euclidean_gradient = euclidean_gradient
         if euclidean_hessian is not None:
+            self._validate_function_backend(
+                euclidean_hessian, "euclidean_hessian", manifold
+            )
             euclidean_hessian = self._wrap_hessian_operator(
                 euclidean_hessian, embed_tangent_vectors=True
             )
         self._euclidean_hessian = euclidean_hessian
 
         if riemannian_gradient is not None:
+            self._validate_function_backend(
+                riemannian_gradient, "riemannian_gradient", manifold
+            )
             riemannian_gradient = self._wrap_gradient_operator(
                 riemannian_gradient
             )
         self._riemannian_gradient = riemannian_gradient
         if riemannian_hessian is not None:
+            self._validate_function_backend(
+                riemannian_hessian, "rimeannian_hessian", manifold
+            )
             riemannian_hessian = self._wrap_hessian_operator(
                 riemannian_hessian
             )
@@ -117,10 +130,19 @@ class Problem:
 
     @staticmethod
     def _validate_function(function, name):
-        if function is not None and not isinstance(function, Function):
-            raise ValueError(
-                f"Function '{name}' must be decorated with a backend decorator"
-            )
+        assert isinstance(
+            function, Function
+        ), f"Function '{name}' must be decorated with a backend decorator."
+
+    @staticmethod
+    def _validate_function_backend(
+        function: Function, name: str, manifold: Manifold
+    ):
+        assert manifold.is_backend_compatible(function.backend), (
+            f"Function '{name}' has a backend {function.backend} "
+            "which is not compatible with the manifold's backend"
+            f" {manifold.backend}."
+        )
 
     def _flatten_arguments(self, arguments, signature):
         assert len(arguments) == len(signature)

--- a/src/pymanopt/function.py
+++ b/src/pymanopt/function.py
@@ -86,6 +86,8 @@ def decorator_factory(
             backend = (
                 backend_type(dtype=dtype)
                 if dtype is not None
+                # by default use float64, which is fine for a function it only
+                # uses autodiff methods (which do not depend on realness)
                 else backend_type()
             )
             return Function(function=cost, manifold=manifold, backend=backend)

--- a/src/pymanopt/function.py
+++ b/src/pymanopt/function.py
@@ -2,7 +2,7 @@ __all__ = ["Function", "autograd", "jax", "numpy", "pytorch", "tensorflow"]
 
 import inspect
 from importlib import import_module
-from typing import Any, Callable
+from typing import Any, Callable, Optional, Protocol
 
 from pymanopt.backends import Backend
 from pymanopt.manifolds.manifold import Manifold
@@ -52,11 +52,18 @@ def _only_one_true(*args):
     return sum(args) == 1
 
 
+class _ObjectiveFunctionDecorator(Protocol):
+    def __call__(
+        self, manifold: Manifold, dtype: Optional[Any] = None
+    ) -> Callable[[Callable[..., Any]], Function]:
+        ...
+
+
 def decorator_factory(
     module: str, backend_class: str
-) -> Callable[[Manifold], Callable[[Callable[..., Any]], Function]]:
+) -> _ObjectiveFunctionDecorator:
     def decorator(
-        manifold: Manifold,
+        manifold: Manifold, dtype: Optional[Any] = None
     ) -> Callable[[Callable[..., Any]], Function]:
         assert isinstance(manifold, Manifold)
 
@@ -70,12 +77,17 @@ def decorator_factory(
                 "Decorated function must only accept positional arguments "
                 "or a variable-length argument like *x"
             )
-            backend = getattr(
+            backend_type = getattr(
                 import_module(
                     f"pymanopt.backends.{module}",
                 ),
                 backend_class,
-            )()
+            )
+            backend = (
+                backend_type(dtype=dtype)
+                if dtype is not None
+                else backend_type()
+            )
             return Function(function=cost, manifold=manifold, backend=backend)
 
         return inner

--- a/src/pymanopt/manifolds/euclidean.py
+++ b/src/pymanopt/manifolds/euclidean.py
@@ -107,11 +107,6 @@ class Euclidean(_Euclidean):
         dimension = math.prod(shape)
         super().__init__(name, dimension, *shape, backend=backend)
 
-        @RiemannianSubmanifold.backend.setter
-        def _(self, backend: Backend):
-            assert backend.is_dtype_real()
-            super().backend = backend
-
 
 class ComplexEuclidean(_Euclidean):
     r"""Complex Euclidean manifold.
@@ -145,15 +140,8 @@ class ComplexEuclidean(_Euclidean):
         dimension = 2 * np.prod(shape)
         super().__init__(name, dimension, *shape, backend=backend)
 
-    @RiemannianSubmanifold.backend.setter
-    def _(self, backend: Backend):
-        assert not backend.is_dtype_real()
-        super().backend = backend
-
     def random_point(self):
-        return self.backend.random_randn(
-            *self._shape
-        ) + 1j * self.backend.random_randn(*self._shape)
+        return self.backend.random_randn(*self._shape)
 
     def zero_vector(self, point):
         return np.zeros(self._shape, dtype=complex)

--- a/src/pymanopt/manifolds/euclidean.py
+++ b/src/pymanopt/manifolds/euclidean.py
@@ -144,7 +144,7 @@ class ComplexEuclidean(_Euclidean):
         return self.backend.random_randn(*self._shape)
 
     def zero_vector(self, point):
-        return np.zeros(self._shape, dtype=complex)
+        return self.backend.zeros(self._shape)
 
 
 class Symmetric(_Euclidean):

--- a/src/pymanopt/manifolds/fixed_rank.py
+++ b/src/pymanopt/manifolds/fixed_rank.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from pymanopt.backends import Backend, DummyBackendSingleton
-from pymanopt.manifolds.manifold import Manifold, RiemannianSubmanifold
+from pymanopt.manifolds.manifold import RiemannianSubmanifold
 from pymanopt.manifolds.stiefel import Stiefel
 from pymanopt.tools import ArraySequenceMixin, return_as_class_instance
 
@@ -112,16 +112,10 @@ class FixedRankEmbedded(RiemannianSubmanifold):
         dimension = (m + n - k) * k
         super().__init__(name, dimension, point_layout=3, backend=backend)
 
-    @Manifold.backend.setter
-    def backend(self, backend: Backend):
-        self._backend = backend
-        self._stiefel_m.backend = backend
-        self._stiefel_n.backend = backend
-
-    def set_backend_with_default_dtype(self, backend_type: type):
-        super().set_backend_with_default_dtype(backend_type)
-        self._stiefel_m.set_backend_with_default_dtype(backend_type)
-        self._stiefel_n.set_backend_with_default_dtype(backend_type)
+    def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
+        self._stiefel_m.set_compatible_backend(other_backend)
+        self._stiefel_n.set_compatible_backend(other_backend)
 
     @property
     def typical_dist(self):

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -71,7 +71,7 @@ class Manifold(metaclass=abc.ABCMeta):
                 f"{type(point_layout)}"
             )
         if isinstance(point_layout, (tuple, list)):
-            if not all([num_arguments > 0 for num_arguments in point_layout]):
+            if not all(num_arguments > 0 for num_arguments in point_layout):
                 raise ValueError(
                     f"Invalid point layout {point_layout}: all values must be "
                     "positive"

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -114,30 +114,27 @@ class Manifold(metaclass=abc.ABCMeta):
         """The numerics backend used by the manifold."""
         return self._backend
 
-    @backend.setter
-    def backend(self, backend: Backend):
-        self._backend = backend
-
     def has_dummy_backend(self) -> bool:
         return self.backend == DummyBackendSingleton
 
-    def set_backend_with_default_dtype(self, backend_type: type):
-        """Set the manifold's backend based on a default.
+    def set_compatible_backend(self, other_backend: Backend):
+        """Set the manifold's backend based on another backend.
 
-        This default depends on the provided backend type, the manifold's
-        :attr:`IS_COMPLEX` property and the default precision of the backend
-        for the corresponding dtype (e.g. for real numbers, NumPy defaults to
-        float64 whereas PyTorch defaults to float32).
+        It sets a backend with the same type (numpy, pytorch, etc.)
+        and dtype precision (single or double) and chooses real or complex
+        based on the manifold type.
         """
-        assert issubclass(backend_type, Backend)
-        self.backend = backend_type(
-            backend_type.DEFAULT_COMPLEX_DTYPE()
+        self.backend = (
+            other_backend.to_complex_backend()
             if self.IS_COMPLEX
-            else backend_type.DEFAULT_REAL_DTYPE()
+            else other_backend.to_real_backend()
         )
 
-    def is_backend_compatible(self, backend_type: type) -> bool:
-        return isinstance(self.backend, backend_type)
+    def is_backend_compatible(self, other_backend: Backend) -> bool:
+        return (
+            type(self.backend) is type(other_backend)
+            and self.backend.dtype_precision == other_backend.dtype_precision
+        )
 
     @property
     def num_values(self) -> int:

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -124,7 +124,7 @@ class Manifold(metaclass=abc.ABCMeta):
         and dtype precision (single or double) and chooses real or complex
         based on the manifold type.
         """
-        self.backend = (
+        self._backend = (
             other_backend.to_complex_backend()
             if self.IS_COMPLEX
             else other_backend.to_real_backend()

--- a/src/pymanopt/manifolds/manifold.py
+++ b/src/pymanopt/manifolds/manifold.py
@@ -84,7 +84,7 @@ class Manifold(metaclass=abc.ABCMeta):
         self._name = name
         self._dimension = dimension
         self._point_layout = point_layout
-        self._backend = backend
+        self.set_compatible_backend(backend)
 
     def __str__(self):
         return self._name
@@ -129,6 +129,11 @@ class Manifold(metaclass=abc.ABCMeta):
             if self.IS_COMPLEX
             else other_backend.to_real_backend()
         )
+        if self._backend != other_backend:
+            warnings.warn(
+                f"Incompatible realness between manifold {self} and backend "
+                f"{other_backend}. Setting a compatible backend."
+            )
 
     def is_backend_compatible(self, other_backend: Backend) -> bool:
         return (

--- a/src/pymanopt/manifolds/product.py
+++ b/src/pymanopt/manifolds/product.py
@@ -1,5 +1,4 @@
 import functools
-import warnings
 from typing import Sequence
 
 import numpy as np
@@ -52,19 +51,17 @@ class Product(Manifold):
     def __init__(
         self,
         manifolds: Sequence[Manifold],
-        backend: Backend = DummyBackendSingleton,
     ):
         for manifold in manifolds:
             if isinstance(manifold, Product):
                 raise ValueError("Nested product manifolds are not supported")
 
-        # check all manifolds have the same backend type
-        # TODO: should we also enforce same precision? (32 vs 64)
-        first_type = type(manifolds[0].backend)
+        # check all manifolds have compatible backends
+        first_backend = manifolds[0].backend
         for manifold in manifolds[1:]:
-            if type(manifold.backend) is not first_type:
+            if not manifold.is_backend_compatible(first_backend):
                 raise ValueError(
-                    "All manifolds in a product must have the same backend type"
+                    "All manifolds in a product must have compatible backends."
                 )
 
         self.manifolds = tuple(manifolds)
@@ -73,19 +70,11 @@ class Product(Manifold):
 
         dimension = np.sum([manifold.dim for manifold in manifolds])
         point_layout = tuple(manifold.point_layout for manifold in manifolds)
-        # TODO: set a backend to be able to accss
         super().__init__(
             name,
             dimension,
             point_layout=point_layout,
-            backend=manifolds[0].backend,
-        )
-
-    @Manifold.backend.setter
-    def backend(self, backend: Backend):
-        warnings.warn(
-            "Setting backend of Product manifold is not supported. "
-            "One should directly set the backend of each underlying manifold."
+            backend=manifolds[0].backend.to_real_backend(),
         )
 
     def has_dummy_backend(self) -> bool:
@@ -94,13 +83,13 @@ class Product(Manifold):
             for manifold in self.manifolds
         )
 
-    def set_backend_with_default_dtype(self, backend_type: type):
+    def set_compatible_backend(self, other_backend: Backend):
         for manifold in self.manifolds:
-            manifold.set_backend_with_default_dtype(backend_type)
+            manifold.set_compatible_backend(other_backend)
 
-    def is_backend_compatible(self, backend_type: type) -> bool:
+    def is_backend_compatible(self, other_backend: Backend) -> bool:
         return all(
-            manifold.is_backend_compatible(backend_type)
+            manifold.is_backend_compatible(other_backend)
             for manifold in self.manifolds
         )
 

--- a/src/pymanopt/manifolds/product.py
+++ b/src/pymanopt/manifolds/product.py
@@ -74,6 +74,9 @@ class Product(Manifold):
             name,
             dimension,
             point_layout=point_layout,
+            # here we arbitrarily use the real version of the backend since
+            # it won't be used for any computation, only possibly for settting
+            # the backend of a function
             backend=manifolds[0].backend.to_real_backend(),
         )
 

--- a/src/pymanopt/manifolds/product.py
+++ b/src/pymanopt/manifolds/product.py
@@ -84,6 +84,7 @@ class Product(Manifold):
         )
 
     def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
         for manifold in self.manifolds:
             manifold.set_compatible_backend(other_backend)
 

--- a/src/pymanopt/manifolds/sphere.py
+++ b/src/pymanopt/manifolds/sphere.py
@@ -202,12 +202,12 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
         dimension = subspace_dimension - 1
         super().__init__(name, dimension, matrix, subspace_projector, backend)
 
-    @RiemannianSubmanifold.backend.setter
-    def _(self, backend: Backend):
-        super().backend = backend
-        self._matrix = backend.array(self._matrix)
-        q, _ = backend.linalg_qr(self._matrix)
-        self._subspace_projector = q @ self.backend.transpose(q)
+    def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
+        bk = self.backend
+        self._matrix = bk.array(self._matrix)
+        q, _ = bk.linalg_qr(self._matrix)
+        self._subspace_projector = q @ bk.transpose(q)
 
 
 @extend_docstring(DOCSTRING_NOTE)

--- a/src/pymanopt/manifolds/sphere.py
+++ b/src/pymanopt/manifolds/sphere.py
@@ -182,32 +182,39 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
         matrix: Matrix whose columns span the intersecting subspace.
     """
 
+    @staticmethod
+    def _compute_subspace_projector(bk: Backend, matrix: Backend.array_t):
+        matrix = bk.array(matrix)
+        q, _ = bk.linalg_qr(matrix)
+        _subspace_projector = bk.eye(matrix.shape[0]) - q @ q.T
+        return matrix, _subspace_projector
+
     def __init__(
         self,
         matrix,
         backend: Backend = NumpyBackend(),  # noqa: B008
     ):
-        if backend is None:
+        if backend == DummyBackendSingleton:
             raise ValueError(
                 f"A backend must always be specified for class {__class__.__name__}"
             )
-        m = matrix.shape[0]
-        q, _ = backend.linalg_qr(matrix)
-        subspace_projector = q @ backend.transpose(q)
+        matrix, subspace_projector = self._compute_subspace_projector(
+            backend, matrix
+        )
         subspace_dimension = backend.linalg_matrix_rank(subspace_projector)
         name = (
-            f"Sphere manifold of {m}-dimensional vectors intersecting a "
-            f"{subspace_dimension}-dimensional subspace"
+            f"Sphere manifold of {matrix.shape[0]}-dimensional vectors "
+            f"intersecting a {subspace_dimension}-dimensional subspace"
         )
         dimension = subspace_dimension - 1
         super().__init__(name, dimension, matrix, subspace_projector, backend)
 
     def set_compatible_backend(self, other_backend: Backend):
         super().set_compatible_backend(other_backend)
-        bk = self.backend
-        self._matrix = bk.array(self._matrix)
-        q, _ = bk.linalg_qr(self._matrix)
-        self._subspace_projector = q @ bk.transpose(q)
+        (
+            self._matrix,
+            self._subspace_projector,
+        ) = self._compute_subspace_projector(self.backend, self._matrix)
 
 
 @extend_docstring(DOCSTRING_NOTE)
@@ -225,31 +232,36 @@ class SphereSubspaceComplementIntersection(
         matrix: Matrix whose columns span the subspace.
     """
 
+    @staticmethod
+    def _compute_subspace_projector(bk: Backend, matrix: Backend.array_t):
+        matrix = bk.array(matrix)
+        q, _ = bk.linalg_qr(matrix)
+        _subspace_projector = bk.eye(matrix.shape[0]) - q @ q.T
+        return matrix, _subspace_projector
+
     def __init__(
         self,
         matrix,
         backend: Backend = NumpyBackend(),  # noqa: B008
     ):
-        if backend is None:
+        if backend == DummyBackendSingleton:
             raise ValueError(
                 f"A backend must always be specified for class {__class__.__name__}"
             )
-        m = matrix.shape[0]
-        q, _ = backend.linalg_qr(matrix)
-        subspace_projector = backend.eye(m) - q @ backend.transpose(q)
+        matrix, subspace_projector = self._compute_subspace_projector(
+            backend, matrix
+        )
         subspace_dimension = backend.linalg_matrix_rank(subspace_projector)
         name = (
-            f"Sphere manifold of {m}-dimensional vectors orthogonal "
+            f"Sphere manifold of {matrix.shape[0]}-dimensional vectors orthogonal "
             f"to a {subspace_dimension}-dimensional subspace"
         )
         dimension = subspace_dimension - 1
         super().__init__(name, dimension, matrix, subspace_projector, backend)
 
-    @RiemannianSubmanifold.backend.setter
-    def _(self, backend: Backend):
-        super().backend = backend
-        self._matrix = backend.array(self._matrix)
-        q, _ = backend.linalg_qr(self._matrix)
-        self._subspace_projector = backend.eye(
-            self.dim
-        ) - q @ self.backend.transpose(q)
+    def set_compatible_backend(self, other_backend: Backend):
+        super().set_compatible_backend(other_backend)
+        (
+            self._matrix,
+            self._subspace_projector,
+        ) = self._compute_subspace_projector(self.backend, self._matrix)

--- a/src/pymanopt/manifolds/sphere.py
+++ b/src/pymanopt/manifolds/sphere.py
@@ -186,7 +186,7 @@ class SphereSubspaceIntersection(_SphereSubspaceIntersectionManifold):
     def _compute_subspace_projector(bk: Backend, matrix: Backend.array_t):
         matrix = bk.array(matrix)
         q, _ = bk.linalg_qr(matrix)
-        _subspace_projector = bk.eye(matrix.shape[0]) - q @ q.T
+        _subspace_projector = q @ q.T
         return matrix, _subspace_projector
 
     def __init__(

--- a/src/pymanopt/optimizers/nelder_mead.py
+++ b/src/pymanopt/optimizers/nelder_mead.py
@@ -12,14 +12,12 @@ from pymanopt.optimizers.steepest_descent import SteepestDescent
 def compute_centroid(manifold, points):
     """Compute the centroid of `points` on the `manifold` as Karcher mean."""
 
-    @pymanopt.function.numpy(manifold)
     def objective(*y):
         if manifold.num_values == 1:
             (y,) = y
         return sum(manifold.dist(y, point) ** 2 for point in points) / 2
 
-    @pymanopt.function.numpy(manifold)
-    def gradient(*y):
+    def riemannian_gradient(*y):
         if manifold.num_values == 1:
             (y,) = y
         return -sum(
@@ -29,7 +27,7 @@ def compute_centroid(manifold, points):
 
     optimizer = SteepestDescent(max_iterations=15, verbosity=0)
     problem = pymanopt.Problem(
-        manifold, objective, riemannian_gradient=gradient
+        manifold, objective, riemannian_gradient=riemannian_gradient
     )
     return optimizer.run(problem).point
 

--- a/src/pymanopt/optimizers/nelder_mead.py
+++ b/src/pymanopt/optimizers/nelder_mead.py
@@ -10,7 +10,7 @@ from pymanopt.optimizers.steepest_descent import SteepestDescent
 
 
 def compute_centroid(manifold, points):
-    """Compute the centroid of `points` on the `manifold` as Karcher mean."""
+    """Compute the centroid of `points` on the `manifold` as intrinsic mean."""
 
     def objective(*y):
         if manifold.num_values == 1:

--- a/src/pymanopt/tools/diagnostics.py
+++ b/src/pymanopt/tools/diagnostics.py
@@ -7,7 +7,7 @@ except ImportError:
     plt = None
 
 
-def identify_linear_piece(x, y, window_length, bk):
+def identify_linear_piece(x, y, window_length):
     """Identify a segment of the curve (x, y) that appears to be linear.
 
     This function attempts to identify a contiguous segment of the curve
@@ -20,18 +20,18 @@ def identify_linear_piece(x, y, window_length, bk):
     """
     residues = []
     polys = []
-    for k in bk.arange(len(x) - window_length):
-        segment = bk.arange(k, k + window_length + 1)
-        poly, residuals, *_ = bk.polyfit(
+    for k in np.arange(len(x) - window_length):
+        segment = np.arange(k, k + window_length + 1)
+        poly, residuals, *_ = np.polyfit(
             x[segment], y[segment], deg=1, full=True
         )
         residues.append(residuals)
         polys.append(poly)
-    residues = bk.array(residues)
-    polys += [bk.zeros(2)] * window_length
-    polys = bk.stack(polys, axis=1)
-    best = bk.argmin(residues)
-    segment = bk.arange(best, best + window_length + 1)
+    residues = np.array(residues)
+    polys += [np.zeros(2)] * window_length
+    polys = np.stack(polys, axis=1)
+    best = np.argmin(residues)
+    segment = np.arange(best, best + window_length + 1)
     poly = polys[:, best]
     return segment, poly
 
@@ -47,7 +47,6 @@ def check_directional_derivative(
     test is based on a truncated Taylor series.
     Both x and d are optional and will be sampled at random if omitted.
     """
-    bk = problem.manifold.backend
     #  If x and / or d are not specified, pick them at random.
     if d is not None and x is None:
         raise ValueError(
@@ -61,15 +60,15 @@ def check_directional_derivative(
     # Compute the value of f at points on the geodesic (or approximation
     # of it) originating from x, along direction d, for step_sizes in a
     # large range given by h.
-    h = bk.logspace(-8, 0, 51)
+    h = np.logspace(-8, 0, 51)
     value = []
     for h_k in h:
         try:
             y = problem.manifold.exp(x, h_k * d)
         except NotImplementedError:
             y = problem.manifold.retraction(x, h_k * d)
-        value.append(problem.cost(y))
-    value = bk.array(value)
+        value.append(float(problem.cost(y)))
+    value = np.array(value)
 
     # Compute the value f0 of f at x and directional derivative at x along d.
     f0 = problem.cost(x)
@@ -79,13 +78,13 @@ def check_directional_derivative(
     if use_quadratic_model:
         hessd = problem.riemannian_hessian(x, d)
         d2f0 = problem.manifold.inner_product(x, hessd, d)
-        model = bk.polyval(bk.array([0.5 * d2f0, df0, f0]), h)
+        model = np.polyval(np.array([0.5 * d2f0, df0, f0]), h)
     else:
-        model = bk.polyval(bk.array([df0, f0]), h)
+        model = np.polyval(np.array([df0, f0]), h)
 
     # Compute the approximation error
-    error = bk.abs(model - value)
-    model_is_exact = bk.all(error < 1e-12)
+    error = np.abs(model - value)
+    model_is_exact = np.all(error < 1e-12)
     if model_is_exact:
         if use_quadratic_model:
             print(
@@ -101,10 +100,10 @@ def check_directional_derivative(
             )
         # The model is exact: all errors are (numerically) zero.
         # Fit line from all points, use log scale only in h.
-        segment = bk.arange(len(h))
-        poly = bk.polyfit(bk.log10(h), error, 1)
+        segment = np.arange(len(h))
+        poly = np.polyfit(np.log10(h), error, 1)
         # Set mean error in log scale for plot.
-        poly[-1] = bk.log10(poly[-1])
+        poly[-1] = np.log10(poly[-1])
     else:
         if use_quadratic_model:
             print(
@@ -124,9 +123,9 @@ def check_directional_derivative(
         # Despite not all coordinates of the model being close to the true
         # value, some entries of 'error' can be zero. To avoid numerical issues
         # we add an epsilon here.
-        eps = bk.eps()
+        eps = float(problem.manifold.backend.eps())
         segment, poly = identify_linear_piece(
-            bk.log10(h), bk.log10(error + eps), window_len, bk
+            np.log10(h), np.log10(error + eps), window_len
         )
     return h, error, segment, poly
 
@@ -295,7 +294,6 @@ def check_hessian(problem, point=None, tangent_vector=None):
 
 
 def check_retraction(manifold, point=None, tangent_vector=None):
-    bk = manifold.backend
     """Check order of agreement between a retraction and the exponential."""
     if plt is None:
         raise RuntimeError(
@@ -331,8 +329,8 @@ def check_retraction(manifold, point=None, tangent_vector=None):
 
     # Compare the retraction and the exponential over steps of varying
     # length, on a wide log-scale.
-    step_sizes = bk.logspace(-12, 0, 251)
-    errors = bk.zeros(step_sizes.shape)
+    step_sizes = np.logspace(-12, 0, 251)
+    errors = np.zeros(step_sizes.shape)
     for k, step_size in enumerate(step_sizes):
         errors[k] = manifold.dist(
             manifold.exp(point, step_size * tangent_vector),
@@ -343,7 +341,7 @@ def check_retraction(manifold, point=None, tangent_vector=None):
     # the error curve which is mostly linear.
     window_length = 10
     segment, poly = identify_linear_piece(
-        bk.log10(step_sizes), bk.log10(errors), window_length, bk
+        np.log10(step_sizes), np.log10(errors), window_length
     )
 
     print(
@@ -352,7 +350,7 @@ def check_retraction(manifold, point=None, tangent_vector=None):
         f"It appears the slope is: {poly[0]}.\n"
         "Note: if the implementation of the exponential map and the\n"
         "retraction are identical, this should be zero: "
-        f"{bk.linalg_norm(errors)}.\n"
+        f"{np.linalg.norm(errors)}.\n"
         "In that case, the slope test is irrelevant.",
     )
 
@@ -370,7 +368,7 @@ def check_retraction(manifold, point=None, tangent_vector=None):
 
     plt.loglog(
         step_sizes[segment],
-        10 ** bk.polyval(poly, bk.log10(step_sizes[segment])),
+        10 ** np.polyval(poly, np.log10(step_sizes[segment])),
         linewidth=3,
     )
     plt.xlabel("Step size multiplier t")

--- a/tests/manifolds/test_fixed_rank.py
+++ b/tests/manifolds/test_fixed_rank.py
@@ -160,7 +160,9 @@ class TestFixedRankEmbeddedManifold:
             bk.transpose(z) @ w, m._apply_ambient_transpose(z, w)
         )
         bk.assert_allclose(
-            bk.transpose(z) @ w, m._apply_ambient_transpose((u, s, v), w)
+            bk.transpose(z) @ w,
+            m._apply_ambient_transpose((u, s, v), w),
+            atol=5e-5,
         )
 
     def test_embedding(self):

--- a/tests/manifolds/test_group.py
+++ b/tests/manifolds/test_group.py
@@ -70,7 +70,7 @@ class TestSpecialOrthogonalGroup:
         X = s.random_point()
         Y = s.random_point()
         Yexplog = s.exp(X, s.log(X, Y))
-        self.backend.assert_allclose(Y, Yexplog)
+        self.backend.assert_allclose(Y, Yexplog, atol=5e-6)
 
     def test_log_exp_inverse(self):
         s = self.so

--- a/tests/manifolds/test_positive_definite.py
+++ b/tests/manifolds/test_positive_definite.py
@@ -227,7 +227,7 @@ class TestSymmetricPositiveDefiniteManifold:
         x = manifold.random_point()
         y = manifold.random_point()
         u = manifold.log(x, y)
-        self.backend.assert_allclose(manifold.exp(x, u), y)
+        self.backend.assert_allclose(manifold.exp(x, u), y, atol=5e-6)
 
     def test_log_exp_inverse(self):
         manifold = self.manifold

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,6 @@ from examples import (
 from examples.advanced import check_gradient, check_hessian, check_retraction
 
 
-# TODO: add back tensorflow
 SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch", "tensorflow"}
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,7 +17,7 @@ from examples.advanced import check_gradient, check_hessian, check_retraction
 
 
 # TODO: add back tensorflow
-SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch"}
+SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch", "tensorflow"}
 
 
 class TestExamples:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,7 +16,8 @@ from examples import (
 from examples.advanced import check_gradient, check_hessian, check_retraction
 
 
-SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch", "tensorflow"}
+# TODO: add back tensorflow
+SUPPORTED_BACKENDS = {"numpy", "autograd", "jax", "pytorch"}
 
 
 class TestExamples:


### PR DESCRIPTION
In this PR we switch back to using plain old `numpy` functions in `diagnostics.py` and remove the backend functions that were necessary for it (`polyfit()` and `polyval()`). This also fixes several issues in the tests that were coming from erroneous manual implementations of these functions in the pytorch and tensorflow backends (that did not provide implementations in the underlying libraries). 

> [!NOTE]
> This PR (#286) is stacked with #284 and #285 (and is at the top of the stack). This means that the branch of #285 is based on the one of #284 and the branch of #286 on the branch of #285. They each treat different issues in the codebase and were split to facilitate reviewing. However, there are still unit tests failing in the first ones, and they are only totally fixed in the last. Thanks for taking that into account during the review.