### PR TITLE
Fix identify_linear_piece

### DIFF
--- a/src/pymanopt/tools/diagnostics.py
+++ b/src/pymanopt/tools/diagnostics.py
@@ -25,7 +25,7 @@ def identify_linear_piece(x, y, window_length):
         poly, residuals, *_ = np.polyfit(
             x[segment], y[segment], deg=1, full=True
         )
-        residues[k] = np.sqrt(residuals)
+        residues[k] = np.sqrt(residuals.item())
         polys[:, k] = poly
     best = np.argmin(residues)
     segment = np.arange(best, best + window_length + 1)


### PR DESCRIPTION
``numpy.polyfit`` returns ``residuals.shape == (1,)`` in the case used here, where ``y`` is 1D