### PR TITLE
Add metric logging to TrustRegions optimizer

### DIFF
--- a/src/pymanopt/optimizers/trust_regions.py
+++ b/src/pymanopt/optimizers/trust_regions.py
@@ -151,7 +151,7 @@ class TrustRegions(Optimizer):
         fx = cost(x)
         fgradx = gradient(x)
         norm_grad = manifold.norm(x, fgradx)
-        numit = 0
+        numit = 0   # this is the number of inner iterations used to reach this (initial) point
 
         # Initialize the trust region radius
         Delta = Delta0

--- a/src/pymanopt/optimizers/trust_regions.py
+++ b/src/pymanopt/optimizers/trust_regions.py
@@ -31,11 +31,11 @@
 # finite-differences of the gradient. The resulting method is called
 # RTR-FD. Some convergence theory for it is available in this paper:
 # @incollection{boumal2015rtrfd
-# 	author={Boumal, N.},
-# 	title={Riemannian trust regions with finite-difference Hessian
+#   author={Boumal, N.},
+#   title={Riemannian trust regions with finite-difference Hessian
 #                      approximations are globally convergent},
-# 	year={2015},
-# 	booktitle={Geometric Science of Information}
+#   year={2015},
+#   booktitle={Geometric Science of Information}
 # }
 
 
@@ -151,7 +151,8 @@ class TrustRegions(Optimizer):
         fx = cost(x)
         fgradx = gradient(x)
         norm_grad = manifold.norm(x, fgradx)
-        numit = 0   # this is the number of inner iterations used to reach this (initial) point
+        # This represents the number of Hessian-vector products in each iteration.
+        hess_vec_evals = 0
 
         # Initialize the trust region radius
         Delta = Delta0
@@ -177,8 +178,12 @@ class TrustRegions(Optimizer):
                 point=x,
                 cost=fx,
                 gradient_norm=norm_grad,
-                num_inner=numit,
+                hess_vec_evals=hess_vec_evals,
             )
+
+            # Restart Hessian-vector calls counter for this iteration.
+            hess_vec_evals = 0
+
             # *************************
             # ** Begin TR Subproblem **
             # *************************
@@ -195,7 +200,7 @@ class TrustRegions(Optimizer):
                     eta = np.sqrt(np.sqrt(np.spacing(1))) * eta
 
             # Solve TR subproblem approximately
-            eta, Heta, numit, stop_inner = self._truncated_conjugate_gradient(
+            eta, Heta, numit, stop_inner, hess_vec_evals_tcg = self._truncated_conjugate_gradient(
                 problem,
                 x,
                 fgradx,
@@ -206,6 +211,7 @@ class TrustRegions(Optimizer):
                 mininner,
                 maxinner,
             )
+            hess_vec_evals += hess_vec_evals_tcg
 
             srstr = self.TCG_STOP_REASONS[stop_inner]
 
@@ -219,6 +225,7 @@ class TrustRegions(Optimizer):
                 used_cauchy = False
                 # Check the curvature
                 Hg = hess(x, fgradx)
+                hess_vec_evals += 1
                 g_Hg = manifold.inner_product(x, fgradx, Hg)
                 if g_Hg <= 0:
                     tau_c = 1
@@ -453,6 +460,7 @@ class TrustRegions(Optimizer):
         inner = manifold.inner_product
         hess = problem.riemannian_hessian
         preconditioner = problem.preconditioner
+        hess_vec_evals_tcg = 0
 
         if not self.use_rand:  # and therefore, eta == 0
             Heta = manifold.zero_vector(x)
@@ -461,6 +469,7 @@ class TrustRegions(Optimizer):
         else:  # and therefore, no preconditioner
             # eta (presumably) ~= 0 was provided by the caller.
             Heta = hess(x, eta)
+            hess_vec_evals_tcg += 1
             r = fgradx + Heta
             e_Pe = inner(x, eta, eta)
 
@@ -509,6 +518,7 @@ class TrustRegions(Optimizer):
         for j in range(int(maxinner)):
             # This call is the computationally intensive step
             Hdelta = hess(x, delta)
+            hess_vec_evals_tcg += 1
 
             # Compute curvature (often called kappa)
             d_Hd = inner(x, delta, Hdelta)
@@ -624,4 +634,4 @@ class TrustRegions(Optimizer):
             e_Pd = beta * (e_Pd + alpha * d_Pd)
             d_Pd = z_r + beta * beta * d_Pd
 
-        return eta, Heta, j, stop_tCG
+        return eta, Heta, j, stop_tCG, hess_vec_evals_tcg

--- a/src/pymanopt/optimizers/trust_regions.py
+++ b/src/pymanopt/optimizers/trust_regions.py
@@ -151,7 +151,8 @@ class TrustRegions(Optimizer):
         fx = cost(x)
         fgradx = gradient(x)
         norm_grad = manifold.norm(x, fgradx)
-        # This represents the number of Hessian-vector products in each iteration.
+        # hess_vec_evals counts the number of Hessian-vector products used to reach
+        # an iteration from the previous one. For the initial point, this is zero.
         hess_vec_evals = 0
 
         # Initialize the trust region radius

--- a/src/pymanopt/optimizers/trust_regions.py
+++ b/src/pymanopt/optimizers/trust_regions.py
@@ -151,6 +151,7 @@ class TrustRegions(Optimizer):
         fx = cost(x)
         fgradx = gradient(x)
         norm_grad = manifold.norm(x, fgradx)
+        numit = 0
 
         # Initialize the trust region radius
         Delta = Delta0
@@ -176,6 +177,7 @@ class TrustRegions(Optimizer):
                 point=x,
                 cost=fx,
                 gradient_norm=norm_grad,
+                num_inner=numit,
             )
             # *************************
             # ** Begin TR Subproblem **

--- a/src/pymanopt/optimizers/trust_regions.py
+++ b/src/pymanopt/optimizers/trust_regions.py
@@ -171,6 +171,12 @@ class TrustRegions(Optimizer):
         while True:
             iteration += 1
 
+            self._add_log_entry(
+                iteration=iteration,
+                point=x,
+                cost=fx,
+                gradient_norm=norm_grad,
+            )
             # *************************
             # ** Begin TR Subproblem **
             # *************************


### PR DESCRIPTION
TrustRegions: Add metric logging for consistency with other optimizers

The TrustRegions optimizer did not log metrics during the optimization loop,
leading to inconsistencies with other optimizers. This change ensures
_add_log_entry(...) is called each time the loop is re-entered, aligning
logging behavior across optimizers.
