### PR TITLE
Fix UnitaryGroup projection

### DIFF
--- a/src/pymanopt/manifolds/group.py
+++ b/src/pymanopt/manifolds/group.py
@@ -45,7 +45,7 @@ class _UnitaryBase(RiemannianSubmanifold):
         return self.norm(point_a, self.log(point_a, point_b))
 
     def projection(self, point, vector):
-        return multiskew(multihconj(point) @ vector)
+        return multiskewh(multihconj(point) @ vector)
 
     def to_tangent_space(self, point, vector):
         return multiskewh(vector)

--- a/tests/manifolds/test_group.py
+++ b/tests/manifolds/test_group.py
@@ -120,13 +120,13 @@ class TestUnitaryGroup:
         )
     
     def test_projection(self):
-        # Construct a random point X on the manifold.
         point = self.manifold.random_point()
 
-        # Construct a vector H in the ambient space.
+        # Construct a vector in the ambient space.
         vector = np.random.normal(size=(self.k, self.n, self.n)) + 1j*np.random.normal(size=(self.k, self.n, self.n))
         tangent_vector = self.manifold.projection(point, vector)
 
+        # Test that the result is tangent to the manifold
         np_testing.assert_almost_equal(
             tangent_vector, -multihconj(tangent_vector)
         )

--- a/tests/manifolds/test_group.py
+++ b/tests/manifolds/test_group.py
@@ -3,7 +3,7 @@ import numpy.testing as np_testing
 import pytest
 
 from pymanopt.manifolds import SpecialOrthogonalGroup, UnitaryGroup
-from pymanopt.tools.multi import multieye, multihconj, multitransp
+from pymanopt.tools.multi import multieye, multihconj, multitransp, multiskewh
 
 
 class TestSpecialOrthogonalGroup:
@@ -115,6 +115,18 @@ class TestUnitaryGroup:
         point = self.product_manifold.random_point()
         tangent_vector = self.product_manifold.random_tangent_vector(point)
         assert (tangent_vector.imag > 0).any()
+        np_testing.assert_almost_equal(
+            tangent_vector, -multihconj(tangent_vector)
+        )
+    
+    def test_projection(self):
+        # Construct a random point X on the manifold.
+        point = self.manifold.random_point()
+
+        # Construct a vector H in the ambient space.
+        vector = np.random.normal(size=(self.k, self.n, self.n)) + 1j*np.random.normal(size=(self.k, self.n, self.n))
+        tangent_vector = self.manifold.projection(point, vector)
+
         np_testing.assert_almost_equal(
             tangent_vector, -multihconj(tangent_vector)
         )

--- a/tests/manifolds/test_group.py
+++ b/tests/manifolds/test_group.py
@@ -3,7 +3,7 @@ import numpy.testing as np_testing
 import pytest
 
 from pymanopt.manifolds import SpecialOrthogonalGroup, UnitaryGroup
-from pymanopt.tools.multi import multieye, multihconj, multitransp, multiskewh
+from pymanopt.tools.multi import multieye, multihconj, multitransp
 
 
 class TestSpecialOrthogonalGroup:
@@ -118,7 +118,7 @@ class TestUnitaryGroup:
         np_testing.assert_almost_equal(
             tangent_vector, -multihconj(tangent_vector)
         )
-    
+
     def test_projection(self):
         point = self.manifold.random_point()
 


### PR DESCRIPTION
##  Fix UnitaryGroup Projection

This PR fixes a bug in the `UnitaryGroup` manifold `projection` method.

### Changes:
- Corrected the projection formula to ensure the result lies in the tangent space.
- Added a unit test to verify that the projection maps ambient vectors to valid tangent vectors.